### PR TITLE
Added an additional null check to prevent java.lang.NullPointerExcept…

### DIFF
--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
@@ -593,7 +593,7 @@ public class SoapUIProject {
 		Set<String> successResponsesCodes = operation.getResponses().keySet().stream().filter(s -> s.startsWith("2")).collect(Collectors.toSet());
 		if (!successResponsesCodes.isEmpty()) {
 			ApiResponse succesResponse = operation.getResponses().get(successResponsesCodes.iterator().next());
-			if (succesResponse.getContent().entrySet() != null && !succesResponse.getContent().entrySet().isEmpty()) {
+			if (succesResponse.getContent() != null && succesResponse.getContent().entrySet() != null && !succesResponse.getContent().entrySet().isEmpty()) {
 				String mediaTypeStr = succesResponse.getContent().entrySet().iterator().next().getKey();
 				restRequest.setMediaType(mediaTypeStr);
 			}


### PR DESCRIPTION
…ion on certain OpenAPI3 yaml files that have success responses but no response content.

"java.lang.NullPointerException: Cannot invoke "io.swagger.v3.oas.models.media.Content.entrySet()" because the return value of "io.swagger.v3.oas.models.responses.ApiResponse.getContent()" is null
at org.apiaddicts.apitools.openapi2soapui.model.SoapUIProject.setRequestMediaType(SoapUIProject.java:596) ~[classes/:na]"

For example converting a following valid petstore yaml would result to a null pointer exception error without this fix: https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml