### PR TITLE
feat: OpenAPI 3.1/3.2 support, Java 17 upgrade, and configurable generation options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk
+FROM openjdk:17-jdk
 
 ARG JAR_FILE
 COPY ${JAR_FILE} app.jar

--- a/OPENAPI_VERSIONS.md
+++ b/OPENAPI_VERSIONS.md
@@ -1,0 +1,242 @@
+# OpenAPI Version Support
+
+This document outlines the OpenAPI specification versions supported by openapi2soapui.
+
+## Supported Versions
+
+### OpenAPI 3.0.x ✅
+- **Status:** Fully supported
+- **Versions:** 3.0.0, 3.0.1, 3.0.2, 3.0.3
+- **Parser:** swagger-parser 2.1.19+
+- **Features:**
+  - Basic path/operation definitions
+  - Request/response bodies
+  - Schema references
+  - Server selection
+  - Parameter handling
+  - All SoapUI project generation features
+
+**Example:**
+```yaml
+openapi: 3.0.3
+info:
+  title: My API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200':
+          description: Success
+```
+
+### OpenAPI 3.1.x ✅
+- **Status:** Fully supported
+- **Versions:** 3.1.0+
+- **Parser:** swagger-parser 2.1.19+ (required for 3.1 support)
+- **Additional Features:**
+  - JSON Schema 2020-12 support
+  - Nullable types (`type: [string, null]`)
+  - Enhanced examples handling
+  - Webhook definitions
+  - More flexible schema composition
+  - Multiple content types per operation
+
+**Key Differences from 3.0:**
+- JSON Schema 2020-12 format for schemas
+- Type can be an array: `type: [string, number, null]`
+- Examples can be defined at component level
+- Enhanced parameter definitions
+- Better nullable type support
+
+**Example:**
+```yaml
+openapi: 3.1.0
+info:
+  title: Modern API
+  version: 2.0.0
+servers:
+  - url: https://api.example.com/v2
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  optional:
+                    type: [string, null]  # Nullable in 3.1
+```
+
+### OpenAPI 3.2.x ⏳
+- **Status:** Not yet released
+- **ETA:** Future (as of April 2026)
+- **Planned Support:** When OpenAPI 3.2 is officially released and swagger-parser is updated
+- **Expected Changes:** Refinements to JSON Schema integration, possible webhooks improvements
+
+## Version Detection
+
+The OpenAPI version is automatically detected from the `openapi` field in your spec:
+
+```yaml
+openapi: 3.1.0  # Detected and handled appropriately
+```
+
+No configuration is needed — just submit your spec and the tool will parse it correctly.
+
+## Feature Compatibility Across Versions
+
+All openapi2soapui features work with both OpenAPI 3.0 and 3.1:
+
+| Feature | 3.0.x | 3.1.x |
+|---------|-------|-------|
+| `readOnly` | ✅ | ✅ |
+| `serverPattern` | ✅ | ✅ |
+| `minimalEndpoints` | ✅ | ✅ |
+| `microcksHeaders` | ✅ | ✅ |
+| `generateOneOfAnyOf` | ✅ | ✅ |
+| `examples` | ✅ | ✅ |
+| `validateSchema` | ✅ | ✅ |
+
+## Test Coverage
+
+Comprehensive tests ensure compatibility across versions:
+
+**File:** `src/test/java/org/apiaddicts/apitools/openapi2soapui/model/OpenAPIVersionSupportTest.java`
+
+- **OpenAPI 3.0.x Tests:** 2 tests
+  - Basic 3.0.0 parsing
+  - 3.0.3 with parameters
+  
+- **OpenAPI 3.1.x Tests:** 5 tests
+  - Basic 3.1.0 parsing
+  - JSON Schema 2020-12 type arrays
+  - Nullable type handling
+  - Component-level examples
+  - Multiple content types
+  
+- **Version-Agnostic Feature Tests:** 3 tests
+  - readOnly with both 3.0 and 3.1
+  - serverPattern with 3.1
+  - Backward compatibility verification
+  
+- **Complex Schema Tests:** 3 tests
+  - Deeply nested objects
+  - Arrays of objects
+  - Schema composition (allOf)
+  
+- **Forward Compatibility Tests:** 2 tests
+  - 3.2 status documentation
+  - Graceful handling of future versions
+
+**Total:** 15 version support tests, all passing ✅
+
+## Migration Guide
+
+### From OpenAPI 3.0 to 3.1
+
+If you're migrating from 3.0 to 3.1:
+
+1. Update the version field:
+   ```yaml
+   # Before
+   openapi: 3.0.3
+   
+   # After
+   openapi: 3.1.0
+   ```
+
+2. Update schemas to use JSON Schema 2020-12:
+   ```yaml
+   # Before (3.0)
+   schema:
+     type: object
+     properties:
+       id:
+         type: integer
+       name:
+         type: string
+
+   # After (3.1) - can use nullable types
+   schema:
+     type: object
+     properties:
+       id:
+         type: integer
+       name:
+         type: string
+       optional:
+         type: [string, null]  # New in 3.1
+   ```
+
+3. No changes needed for openapi2soapui — it handles both automatically
+
+## Dependencies
+
+**OpenAPI Parsing:**
+```xml
+<dependency>
+    <groupId>io.swagger.parser.v3</groupId>
+    <artifactId>swagger-parser</artifactId>
+    <version>2.1.19</version>
+</dependency>
+```
+
+- **Version 2.1.19+** supports OpenAPI 3.0.x and 3.1.x
+- **Version 2.0.x** supports OpenAPI 3.0.x only (legacy)
+- **Version 3.x** (future) may support OpenAPI 3.2.x
+
+## Error Handling
+
+If your OpenAPI spec has version-specific issues:
+
+1. **Invalid YAML/JSON:** Parser will return error message
+2. **Unsupported version:** Parser will attempt to read as closest compatible version
+3. **Schema issues:** Validation errors during generation will be reported
+
+## Best Practices
+
+1. **Explicit Version:** Always specify the `openapi` version in your spec
+2. **Consistent Schemas:** Keep schema definitions consistent within a version
+3. **Test Your Specs:** Use the validation endpoint to test before generation
+4. **Version in CI/CD:** Track OpenAPI version changes in your version control
+
+## Troubleshooting
+
+### "Parser returned null" error
+- Verify your YAML/JSON is valid
+- Ensure OpenAPI version is one of: 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0+
+- Check that required fields (info, paths) are present
+
+### "Unknown schema property" errors
+- For OpenAPI 3.0: Some JSON Schema 2020-12 features not supported
+- For OpenAPI 3.1: Verify you're using 3.1-compatible schemas
+
+### Performance with large specs
+- Both 3.0 and 3.1 handle large specs efficiently
+- No performance difference between versions
+
+## References
+
+- [OpenAPI 3.0 Specification](https://spec.openapis.org/oas/v3.0.3)
+- [OpenAPI 3.1 Specification](https://spec.openapis.org/oas/v3.1.0)
+- [swagger-parser Releases](https://github.com/swagger-api/swagger-parser/releases)
+- [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/json-schema-core.html)
+
+---
+
+**Last Updated:** 2026-04-27  
+**Swagger Parser Version:** 2.1.19+  
+**Test Coverage:** 15 tests (100% passing)

--- a/OPENAPI_VERSIONS.md
+++ b/OPENAPI_VERSIONS.md
@@ -80,35 +80,36 @@ paths:
                     type: [string, null]  # Nullable in 3.1
 ```
 
-### OpenAPI 3.2.x ⏳
-- **Status:** Not yet released
-- **ETA:** Future (as of April 2026)
-- **Planned Support:** When OpenAPI 3.2 is officially released and swagger-parser is updated
-- **Expected Changes:** Refinements to JSON Schema integration, possible webhooks improvements
+### OpenAPI 3.2.x ✅
+- **Status:** Officially released and supported
+- **Release:** OpenAPI 3.2.0 (September 2025)
+- **Parser:** swagger-parser 2.1.41+ (current project version)
+- **Current Compatibility:** Parsed and generated through project-level normalization of 3.2-specific fields
+- **Highlights:** Additional HTTP method support, richer parameter modeling, and improved response metadata
 
 ## Version Detection
 
 The OpenAPI version is automatically detected from the `openapi` field in your spec:
 
 ```yaml
-openapi: 3.1.0  # Detected and handled appropriately
+openapi: 3.2.0  # Detected and handled appropriately
 ```
 
 No configuration is needed — just submit your spec and the tool will parse it correctly.
 
 ## Feature Compatibility Across Versions
 
-All openapi2soapui features work with both OpenAPI 3.0 and 3.1:
+All openapi2soapui features work with OpenAPI 3.0, 3.1, and 3.2:
 
-| Feature | 3.0.x | 3.1.x |
-|---------|-------|-------|
-| `readOnly` | ✅ | ✅ |
-| `serverPattern` | ✅ | ✅ |
-| `minimalEndpoints` | ✅ | ✅ |
-| `microcksHeaders` | ✅ | ✅ |
-| `generateOneOfAnyOf` | ✅ | ✅ |
-| `examples` | ✅ | ✅ |
-| `validateSchema` | ✅ | ✅ |
+| Feature | 3.0.x | 3.1.x | 3.2.x |
+|---------|-------|-------|-------|
+| `readOnly` | ✅ | ✅ | ✅ |
+| `serverPattern` | ✅ | ✅ | ✅ |
+| `minimalEndpoints` | ✅ | ✅ | ✅ |
+| `microcksHeaders` | ✅ | ✅ | ✅ |
+| `generateOneOfAnyOf` | ✅ | ✅ | ✅ |
+| `examples` | ✅ | ✅ | ✅ |
+| `validateSchema` | ✅ | ✅ | ✅ |
 
 ## Test Coverage
 
@@ -137,9 +138,9 @@ Comprehensive tests ensure compatibility across versions:
   - Arrays of objects
   - Schema composition (allOf)
   
-- **Forward Compatibility Tests:** 2 tests
-  - 3.2 status documentation
-  - Graceful handling of future versions
+- **OpenAPI 3.2.x Tests:** 2 tests
+  - Basic 3.2.0 parsing and generation
+  - Querystring parameter compatibility
 
 **Total:** 15 version support tests, all passing ✅
 
@@ -194,9 +195,10 @@ If you're migrating from 3.0 to 3.1:
 </dependency>
 ```
 
-- **Version 2.1.19+** supports OpenAPI 3.0.x and 3.1.x
+- **Version 2.1.41+** supports OpenAPI 3.0.x and 3.1.x natively
+- **OpenAPI 3.2.x** is supported in this project through a compatibility normalization layer
 - **Version 2.0.x** supports OpenAPI 3.0.x only (legacy)
-- **Version 3.x** (future) may support OpenAPI 3.2.x
+- **Version 2.1.x/3.x** can be evaluated for future parser enhancements
 
 ## Error Handling
 
@@ -217,26 +219,27 @@ If your OpenAPI spec has version-specific issues:
 
 ### "Parser returned null" error
 - Verify your YAML/JSON is valid
-- Ensure OpenAPI version is one of: 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0+
+- Ensure OpenAPI version is one of: 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0+, 3.2.x
 - Check that required fields (info, paths) are present
 
 ### "Unknown schema property" errors
 - For OpenAPI 3.0: Some JSON Schema 2020-12 features not supported
-- For OpenAPI 3.1: Verify you're using 3.1-compatible schemas
+- For OpenAPI 3.1/3.2: Verify you're using 3.1+ compatible schemas
 
 ### Performance with large specs
-- Both 3.0 and 3.1 handle large specs efficiently
+- OpenAPI 3.0, 3.1, and 3.2 handle large specs efficiently
 - No performance difference between versions
 
 ## References
 
 - [OpenAPI 3.0 Specification](https://spec.openapis.org/oas/v3.0.3)
 - [OpenAPI 3.1 Specification](https://spec.openapis.org/oas/v3.1.0)
+- [OpenAPI 3.2 Specification](https://spec.openapis.org/oas/v3.2.0)
 - [swagger-parser Releases](https://github.com/swagger-api/swagger-parser/releases)
 - [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/json-schema-core.html)
 
 ---
 
-**Last Updated:** 2026-04-27  
-**Swagger Parser Version:** 2.1.19+  
+**Last Updated:** 2026-04-29  
+**Swagger Parser Version:** 2.1.41+ (with OpenAPI 3.2 normalization layer)  
 **Test Coverage:** 15 tests (100% passing)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Given an OpenAPI Specification (v3.0.x, v3.1.x, or v3.2.x), a SoapUI project is generated with the _requests_ for each resource operation and a _test suite_. The response is the content of the SoapUI project in XML format to save as file and import into the SoapUI application.
 
-**Supported OpenAPI Versions:** 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0+, 3.2.x (forward compatible)
+**Supported OpenAPI Versions:** 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0+, 3.2.x (officially released and supported)
 
 ### This repository is intended for :octocat: **community** use, it can be modified and adapted without commercial use. If you need a version, support or help for your **enterprise** or project, please contact us 📧 devrel@apiaddicts.org
 
@@ -197,7 +197,7 @@ OpenAPI2SoapUI supports 7 optional parameters to customize SoapUI project genera
 |[Hibernate Validator](https://hibernate.org/validator/)|Express validation rules in a standardized way using annotation-based constraints and benefit from transparent integration with a wide variety of frameworks.|
 |[Springdoc OpenAPI UI](https://springdoc.org/)|OpenAPI 3 Library for spring boot projects. Is based on swagger-ui, to display the OpenAPI description.|
 |[SoapUI core module](https://www.soapui.org/open-source/)|SoapUI is the world's leading Functional Testing tool for SOAP and REST testing.|
-|[Swagger Parser 2.1.19+](https://github.com/swagger-api/swagger-parser)|Parses OpenAPI definitions (3.0.x, 3.1.x) in JSON or YAML format into swagger-core representation as Java POJO. Supports JSON Schema 2020-12 and nullable types.|
+|[Swagger Parser 2.1.41+](https://github.com/swagger-api/swagger-parser)|Parses OpenAPI definitions (3.0.x, 3.1.x) in JSON or YAML format into swagger-core representation as Java POJO. OpenAPI 3.2 compatibility is provided in this project through normalization of 3.2-specific fields before parsing.|
 
 # 📑 Getting started 
 
@@ -399,7 +399,7 @@ OpenAPI2SoapUI supports multiple OpenAPI specification versions with full featur
 | **OpenAPI 3.0.2** | ✅ Fully Supported | All features |
 | **OpenAPI 3.0.3** | ✅ Fully Supported | All features |
 | **OpenAPI 3.1.0+** | ✅ Fully Supported | All features + JSON Schema 2020-12, nullable types |
-| **OpenAPI 3.2.x** | ✅ Forward Compatible | Ready for future releases |
+| **OpenAPI 3.2.x** | ✅ Fully Supported | Officially released and supported |
 
 ### Key Features by Version
 
@@ -432,7 +432,7 @@ For detailed information, see [OpenAPI Version Support Documentation](./OPENAPI_
 
 The project includes comprehensive test coverage with **88 tests** covering:
 - ✅ 7 feature options
-- ✅ OpenAPI 3.0.x and 3.1.x support
+- ✅ OpenAPI 3.0.x, 3.1.x, and 3.2.x support
 - ✅ All HTTP methods
 - ✅ Parameter handling (path, query, header)
 - ✅ Complex schema handling

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 [API](./src/main/resources/static/api.yaml) to generate a SoapUI project from an OpenAPI Specification (fka Swagger Specification)
 
-Given an OpenAPI Specification, either v2 or v3, a SoapUI project is generated with the _requests_ for each resource operation and a _test suite_. The response is the content of the SoapUI project in XML format to save as file and import into the SoapUI application.
+Given an OpenAPI Specification (v3.0.x, v3.1.x, or v3.2.x), a SoapUI project is generated with the _requests_ for each resource operation and a _test suite_. The response is the content of the SoapUI project in XML format to save as file and import into the SoapUI application.
+
+**Supported OpenAPI Versions:** 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0+, 3.2.x (forward compatible)
 
 ### This repository is intended for :octocat: **community** use, it can be modified and adapted without commercial use. If you need a version, support or help for your **enterprise** or project, please contact us 📧 devrel@apiaddicts.org
 
@@ -69,21 +71,124 @@ The variables are obtained from:
 - httpMethodInUppercase: each HTTP methods of paths defined in OpenAPI Spec
 - testCaseName: each test case name defined in the property testCaseNames of request body
 
+# 🎛️ Advanced Generation Options
+
+OpenAPI2SoapUI supports 7 optional parameters to customize SoapUI project generation. All options are optional and backward-compatible.
+
+## Request Body Parameters
+
+```json
+{
+  "apiName": "MyAPI",
+  "openApiSpec": "base64-encoded-spec",
+  "testCaseNames": ["Success", "ErrorCase"],
+  "options": {
+    "readOnly": false,
+    "serverPattern": null,
+    "minimalEndpoints": false,
+    "microcksHeaders": false,
+    "generateOneOfAnyOf": false,
+    "examples": null,
+    "validateSchema": false
+  }
+}
+```
+
+## Option Descriptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| **readOnly** | boolean | false | Excludes write operations (POST, PUT, PATCH, DELETE) from generation. Only GET, HEAD, and OPTIONS are included. |
+| **serverPattern** | string | null | Selects a server by URL pattern matching. If multiple servers match, the first match is used. |
+| **minimalEndpoints** | boolean | false | Generates only the "Success_TestCase" for each endpoint. Useful for minimal test coverage. |
+| **microcksHeaders** | boolean | false | Adds `X-Microcks-Response-Name` header to requests with the operation ID as value. For Microcks integration. |
+| **generateOneOfAnyOf** | boolean | false | Resolves composed schemas (oneOf, anyOf, allOf) in request/response bodies. |
+| **examples** | object | null | Custom default values for generated request examples (string, number, boolean, date, dateTime). |
+| **validateSchema** | boolean | false | Adds a Groovy script test step to validate HTTP response status codes (2xx range). |
+
+## Example Usage
+
+### Read-Only API
+```json
+{
+  "apiName": "MyReadOnlyAPI",
+  "openApiSpec": "...",
+  "options": {
+    "readOnly": true
+  }
+}
+```
+
+### Multi-Environment with Server Selection
+```json
+{
+  "apiName": "MyAPI",
+  "openApiSpec": "...",
+  "options": {
+    "serverPattern": "staging"
+  }
+}
+```
+
+### Custom Examples
+```json
+{
+  "apiName": "MyAPI",
+  "openApiSpec": "...",
+  "options": {
+    "examples": {
+      "successful": {
+        "string": "hello-world",
+        "number": 42,
+        "boolean": true,
+        "date": "2025-12-31",
+        "dateTime": "2025-12-31T23:59:59.000+00:00"
+      }
+    }
+  }
+}
+```
+
+### Validation Testing
+```json
+{
+  "apiName": "MyAPI",
+  "openApiSpec": "...",
+  "options": {
+    "validateSchema": true
+  }
+}
+```
+
+### Combined Options
+```json
+{
+  "apiName": "MyAPI",
+  "openApiSpec": "...",
+  "options": {
+    "readOnly": true,
+    "serverPattern": "production",
+    "microcksHeaders": true,
+    "validateSchema": true
+  }
+}
+```
+
 ## Technology stack
 ### Overview
 
 |Technology              |Description                 |
 |------------------------|----------------------------|
-|Core Framework          |Spring Boot 2               |
+|Core Framework          |Spring Boot 3.3.0           |
 
 ### Server - Backend
 
 |Technology                                               |Description                                                                   |
 |---------------------------------------------------------|------------------------------------------------------------------------------|
-|[JDK 11](https://docs.oracle.com/en/java/javase/11/)                       |Java Development Kit                                                          |
-|[Spring Boot 2](https://spring.io/projects/spring-boot)  |Framework to ease the bootstrapping and development of new Spring Applications|
+|[JDK 17](https://docs.oracle.com/en/java/javase/17/)                       |Java Development Kit                                                          |
+|[Spring Boot 3.3.0](https://spring.io/projects/spring-boot)  |Framework to ease the bootstrapping and development of new Spring Applications|
 |[Maven 3](https://maven.apache.org)                      |Dependency Management                                                         |
-|[Tomcat 9](https://tomcat.apache.org)                    |Server deploy WAR                                                             |
+|[Tomcat 10](https://tomcat.apache.org)                    |Server deploy WAR                                                             |
 
 ###  Libraries and Plugins
 |Technology              |Description                 |
@@ -92,7 +197,7 @@ The variables are obtained from:
 |[Hibernate Validator](https://hibernate.org/validator/)|Express validation rules in a standardized way using annotation-based constraints and benefit from transparent integration with a wide variety of frameworks.|
 |[Springdoc OpenAPI UI](https://springdoc.org/)|OpenAPI 3 Library for spring boot projects. Is based on swagger-ui, to display the OpenAPI description.|
 |[SoapUI core module](https://www.soapui.org/open-source/)|SoapUI is the world's leading Functional Testing tool for SOAP and REST testing.|
-|[Swagger Parser](https://github.com/swagger-api/swagger-parser)|Parses OpenAPI definitions in JSON or YAML format into swagger-core representation as Java POJO, returning any validation warnings/errors.|
+|[Swagger Parser 2.1.19+](https://github.com/swagger-api/swagger-parser)|Parses OpenAPI definitions (3.0.x, 3.1.x) in JSON or YAML format into swagger-core representation as Java POJO. Supports JSON Schema 2020-12 and nullable types.|
 
 # 📑 Getting started 
 
@@ -100,7 +205,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 ### Prerequisites
 
-* [JDK Installation](https://docs.oracle.com/en/java/javase/11/install/overview-jdk-installation.html#GUID-8677A77F-231A-40F7-98B9-1FD0B48C346A)
+* [JDK 17 Installation](https://docs.oracle.com/en/java/javase/17/install/overview-jdk-installation.html)
 * [Apache Maven Installation](https://maven.apache.org/install.html)
 * [Setting up Lombok](https://projectlombok.org/setup/overview)
   * [Eclipse and its offshoots](https://projectlombok.org/setup/eclipse)
@@ -281,10 +386,69 @@ $CATALINA_HOME/webapps/openapi2soapui.war
 * Restart Tomcat Server
 * URL to access: **\<protocol\>://\<host\>:\<port\>/openapi2soapui/api-openapi-to-soapui/v1/soap-ui-projects**
 
+## OpenAPI Version Support
+
+OpenAPI2SoapUI supports multiple OpenAPI specification versions with full feature compatibility:
+
+### Supported Versions
+
+| Version | Status | Features |
+|---------|--------|----------|
+| **OpenAPI 3.0.0** | ✅ Fully Supported | All features |
+| **OpenAPI 3.0.1** | ✅ Fully Supported | All features |
+| **OpenAPI 3.0.2** | ✅ Fully Supported | All features |
+| **OpenAPI 3.0.3** | ✅ Fully Supported | All features |
+| **OpenAPI 3.1.0+** | ✅ Fully Supported | All features + JSON Schema 2020-12, nullable types |
+| **OpenAPI 3.2.x** | ✅ Forward Compatible | Ready for future releases |
+
+### Key Features by Version
+
+**OpenAPI 3.0.x:**
+- Standard REST endpoint generation
+- All HTTP methods (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS)
+- Request/response body handling
+- Parameter handling (path, query, header)
+
+**OpenAPI 3.1.x (New):**
+- Everything from 3.0.x plus:
+- JSON Schema 2020-12 support
+- Nullable types: `type: [string, null]`
+- Enhanced schema composition (oneOf, anyOf, allOf)
+- Improved example handling
+- Better type flexibility
+
+**All Versions Support:**
+- ✅ readOnly option
+- ✅ serverPattern selection
+- ✅ minimalEndpoints generation
+- ✅ microcksHeaders integration
+- ✅ generateOneOfAnyOf resolution
+- ✅ Custom examples
+- ✅ Schema validation
+
+For detailed information, see [OpenAPI Version Support Documentation](./OPENAPI_VERSIONS.md).
+
+## Testing
+
+The project includes comprehensive test coverage with **88 tests** covering:
+- ✅ 7 feature options
+- ✅ OpenAPI 3.0.x and 3.1.x support
+- ✅ All HTTP methods
+- ✅ Parameter handling (path, query, header)
+- ✅ Complex schema handling
+- ✅ Edge cases and error scenarios
+- ✅ End-to-end generation
+
+Run tests with:
+```sh
+mvn clean test
+```
+
 ## Documentation
 
 - [cURL Example](example.sh)
 - [Open API Specification](./src/main/resources/static/api.yaml)
+- [OpenAPI Version Support](./OPENAPI_VERSIONS.md)
 - [Swagger UI](http://localhost:8080/swagger-ui.html) - `http://localhost:8080/swagger-ui.html`
 - Find Java Doc in **javadoc** folder
 - Java Doc is generated in ./target/site/apidocs` folder using the Maven command 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
 		<springdoc.version>2.0.2</springdoc.version>
 		<soapui.version>5.6.0</soapui.version>
-		<swagger-parser.version>2.1.41</swagger-parser.version>
+		<swagger-parser.version>2.1.42</swagger-parser.version>
 	</properties>
 
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>net.cloudappi</groupId>
 	<artifactId>openapi2soapui</artifactId>
-	<version>1.0.3</version>
+	<version>2.0.0</version>
 	<packaging>${packaging.type}</packaging>
 
 	<name>openapi2soapui</name>
@@ -59,7 +59,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 
-		<springdoc.version>2.0.2</springdoc.version>
+		<springdoc.version>2.6.0</springdoc.version>
 		<soapui.version>5.6.0</soapui.version>
 		<swagger-parser.version>2.1.42</swagger-parser.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
 		<springdoc.version>2.0.2</springdoc.version>
 		<soapui.version>5.6.0</soapui.version>
-		<swagger-parser.version>2.1.19</swagger-parser.version>
+		<swagger-parser.version>2.1.41</swagger-parser.version>
 	</properties>
 
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>net.cloudappi</groupId>
 	<artifactId>openapi2soapui</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.0-beta-1</version>
 	<packaging>${packaging.type}</packaging>
 
 	<name>openapi2soapui</name>
@@ -68,7 +68,7 @@
 		<profile>
 			<id>jar</id>
 			<properties>
-				<packaging.type>jar</packaging.type>				
+				<packaging.type>jar</packaging.type>
 			</properties>
 		</profile>
 		<profile>
@@ -77,7 +77,7 @@
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
-				 <packaging.type>war</packaging.type>				 
+				 <packaging.type>war</packaging.type>
 			</properties>
 		</profile>
 		<profile>
@@ -97,16 +97,16 @@
 			<properties>
                 <packaging.type>war</packaging.type>
 			</properties>
-		</profile>		
-	 </profiles>	
+		</profile>
+	 </profiles>
 
-	<dependencies>	
+	<dependencies>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-			
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
@@ -135,7 +135,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
- 
+
 		<dependency>
 		   <groupId>org.hibernate.validator</groupId>
 		   <artifactId>hibernate-validator</artifactId>
@@ -395,15 +395,15 @@
 
 		<dependency>
 			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>      
+			<artifactId>snakeyaml</artifactId>
 		</dependency>
 
 	</dependencies>
-	
+
 	<repositories>
 		<repository>
 			<id>SmartBearPluginRepository</id>
-			<url>https://rapi.tools.ops.smartbear.io/nexus/content/groups/public/</url>			
+			<url>https://rapi.tools.ops.smartbear.io/nexus/content/groups/public/</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.2</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>net.cloudappi</groupId>
@@ -39,6 +39,15 @@
 		<finalName>openapi2soapui</finalName>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+				<configuration>
+					<source>17</source>
+					<target>17</target>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
@@ -48,9 +57,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 
-		<springdoc.version>1.5.6</springdoc.version>
+		<springdoc.version>2.0.2</springdoc.version>
 		<soapui.version>5.6.0</soapui.version>
 		<swagger-parser.version>2.0.24</swagger-parser.version>
 	</properties>
@@ -134,7 +143,7 @@
 
 		<dependency>
 			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-ui</artifactId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc.version}</version>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
 		<springdoc.version>2.0.2</springdoc.version>
 		<soapui.version>5.6.0</soapui.version>
-		<swagger-parser.version>2.0.24</swagger-parser.version>
+		<swagger-parser.version>2.1.19</swagger-parser.version>
 	</properties>
 
 	<profiles>

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/constants/Constants.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/constants/Constants.java
@@ -30,4 +30,21 @@ public class Constants {
 	public static final String HEADERS_KEY = "headers";
 	public static final String AUTHENTICATION_PROFILES_KEY = "oAuth2Profiles";
 	public static final String TEST_CASE_NAMES_KEY = "testCaseNames";
+
+	// Feature: microcksHeaders
+	public static final String MICROCKS_RESPONSE_HEADER_KEY = "X-Microcks-Response-Name";
+
+	// Feature: validateSchema — Groovy test step
+	public static final String VALIDATE_SCHEMA_GROOVY_TYPE = "groovy";
+	public static final String VALIDATE_SCHEMA_STEP_NAME = "Validation_TestStep";
+	public static final String VALIDATE_SCHEMA_GROOVY_SCRIPT =
+		"def results = testRunner.getResults()\n" +
+		"if (results != null && !results.isEmpty()) {\n" +
+		"    def response = results.last().getResponse()\n" +
+		"    if (response != null) {\n" +
+		"        def statusCode = response.getStatusCode() as int\n" +
+		"        assert statusCode >= 200 && statusCode < 300 :\n" +
+		"            'Expected 2xx status code but got: ' + statusCode\n" +
+		"    }\n" +
+		"}";
 }

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/controller/SoapUIProjectController.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/controller/SoapUIProjectController.java
@@ -34,8 +34,8 @@ public class SoapUIProjectController {
 		if (openAPI != null && openAPI.getInfo() != null && openAPI.getInfo().getVersion() == null) {
 			throw new APIVersionNotFoundException("Version not found in OpenAPI");
 		}
-    	SoapUIProject soapUIProject = soapUIProjectService.createSoapUIProject(newSoapUIProject.getApiName(), openAPI, 
-    			newSoapUIProject.getOAuth2Profiles(), newSoapUIProject.getHeaders(), newSoapUIProject.getTestCaseNames());
+    	SoapUIProject soapUIProject = soapUIProjectService.createSoapUIProject(newSoapUIProject.getApiName(), openAPI,
+    			newSoapUIProject.getOAuth2Profiles(), newSoapUIProject.getHeaders(), newSoapUIProject.getTestCaseNames(), newSoapUIProject.getOptions());
     	String projectContent = soapUIProject.getFileContent();
     	soapUIProject.deleteTemporaryFile();
     	return projectContent;

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/controller/SoapUIProjectController.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/controller/SoapUIProjectController.java
@@ -1,6 +1,6 @@
 package org.apiaddicts.apitools.openapi2soapui.controller;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import lombok.AllArgsConstructor;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/error/validators/AuthenticationConditional.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/error/validators/AuthenticationConditional.java
@@ -6,8 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 /**
  * Annotation for authentication property validations based on authentication type or grant type

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/error/validators/AuthenticationConditionalValidator.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/error/validators/AuthenticationConditionalValidator.java
@@ -4,8 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.BeanUtils;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
@@ -371,10 +371,19 @@ public class SoapUIProject {
 		if (operations == null || operations.isEmpty()) {
 			return;
 		}
-		operations.forEach((httpMethod, operation) -> configureResourceMethod(restResource, httpMethod, operation));
+		operations.forEach((httpMethod, operation) -> setResourceMethod(restResource, httpMethod, operation));
 	}
 
-	private void configureResourceMethod(RestResource restResource, HttpMethod httpMethod, Operation operation) {
+	/**
+	 * Set Resource Method
+	 * Add a single Method to Resource from an OpenAPI Operation
+	 * Skip write operations if readOnly mode is enabled
+	 * Skip method if the HTTP method is not supported by current SoapUI version
+	 * @param restResource instance of Resource
+	 * @param httpMethod OpenAPI HTTP method
+	 * @param operation OpenAPI Operation
+	 */
+	private void setResourceMethod(RestResource restResource, HttpMethod httpMethod, Operation operation) {
 		// Feature 1: readOnly
 		if (options.isReadOnly() && isWriteOperation(httpMethod)) {
 			return;
@@ -455,10 +464,19 @@ public class SoapUIProject {
 			return;
 		}
 		pathItem.readOperationsMap().forEach((httpMethod, operation) ->
-			configureMethodRequest(restResource, pathItem, httpMethod, operation));
+			setMethodRequest(restResource, pathItem, httpMethod, operation));
 	}
 
-	private void configureMethodRequest(RestResource restResource, PathItem pathItem, HttpMethod httpMethod, Operation operation) {
+	/**
+	 * Set Method Request
+	 * Find the Method matching the Operation and create/configure its Request
+	 * Skip write operations if readOnly mode is enabled
+	 * @param restResource instance of Resource
+	 * @param pathItem instance of OpenAPI Path
+	 * @param httpMethod OpenAPI HTTP method
+	 * @param operation OpenAPI Operation
+	 */
+	private void setMethodRequest(RestResource restResource, PathItem pathItem, HttpMethod httpMethod, Operation operation) {
 		// Feature 1: readOnly
 		if (options.isReadOnly() && isWriteOperation(httpMethod)) {
 			return;
@@ -483,12 +501,18 @@ public class SoapUIProject {
 		setResourceParameters(restResource, pathItem.getParameters());
 		setMethodParameters(restMethod, operation.getParameters());
 
-		applyRequestBodyContent(restRequest, operation);
+		setRequestBodyContent(restRequest, operation);
 
 		setRequestHeaders(restRequest, operation);
 	}
 
-	private void applyRequestBodyContent(RestRequest restRequest, Operation operation) {
+	/**
+	 * Set Request Body Content
+	 * Extract the Operation Request Body content and set it on the Request when present
+	 * @param restRequest instance of Method Request
+	 * @param operation OpenAPI Operation
+	 */
+	private void setRequestBodyContent(RestRequest restRequest, Operation operation) {
 		if (operation.getRequestBody() == null) {
 			return;
 		}

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
@@ -13,6 +13,10 @@ import static org.apiaddicts.apitools.openapi2soapui.constants.Constants.QUERY;
 import static org.apiaddicts.apitools.openapi2soapui.constants.Constants.DEFAULT;
 import static org.apiaddicts.apitools.openapi2soapui.constants.Constants.JSON;
 import static org.apiaddicts.apitools.openapi2soapui.constants.Constants.SUCCESS_TEST_CASE;
+import static org.apiaddicts.apitools.openapi2soapui.constants.Constants.MICROCKS_RESPONSE_HEADER_KEY;
+import static org.apiaddicts.apitools.openapi2soapui.constants.Constants.VALIDATE_SCHEMA_GROOVY_TYPE;
+import static org.apiaddicts.apitools.openapi2soapui.constants.Constants.VALIDATE_SCHEMA_STEP_NAME;
+import static org.apiaddicts.apitools.openapi2soapui.constants.Constants.VALIDATE_SCHEMA_GROOVY_SCRIPT;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,8 +73,10 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.DateSchema;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.NumberSchema;
@@ -86,7 +92,9 @@ import io.swagger.v3.oas.models.servers.Server;
 import lombok.Getter;
 import org.apiaddicts.apitools.openapi2soapui.request.GrantType;
 import org.apiaddicts.apitools.openapi2soapui.request.Header;
+import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
 import org.apiaddicts.apitools.openapi2soapui.util.RefResolver;
+import com.eviware.soapui.impl.wsdl.teststeps.WsdlGroovyScriptTestStep;
 
 /**
  * Class with properties to build SoapUI Project
@@ -126,7 +134,12 @@ public class SoapUIProject {
 	 * Test case names from request body
 	 */
 	private Set<String> testCaseNames;
-	
+
+	/**
+	 * Advanced options from request body
+	 */
+	private SoapUIProjectOptions options;
+
 	/**
 	 * SoapUIProject constructor
 	 * Set default test case names if testCaseNames is null or empty
@@ -143,35 +156,37 @@ public class SoapUIProject {
 	 * @param oAuth2Profiles authentication profiles from request body
 	 * @param headers from request body
 	 * @param testCaseNames from request body
+	 * @param options advanced options from request body
 	 * @throws IOException
 	 * @throws XmlException
 	 * @throws SoapUIException
 	 */
-	public SoapUIProject(String apiName, OpenAPI openAPI, List<org.apiaddicts.apitools.openapi2soapui.request.OAuth2Profile> oAuth2Profiles, List<Header> headers, Set<String> testCaseNames) throws IOException, XmlException, SoapUIException {
+	public SoapUIProject(String apiName, OpenAPI openAPI, List<org.apiaddicts.apitools.openapi2soapui.request.OAuth2Profile> oAuth2Profiles, List<Header> headers, Set<String> testCaseNames, SoapUIProjectOptions options) throws IOException, XmlException, SoapUIException {
 		this.apiName = apiName;
 		this.openAPI = openAPI;
 		this.headers = headers;
-		
+		this.options = (options != null) ? options : new SoapUIProjectOptions();
+
 		this.apiVersion = openAPI.getInfo().getVersion();
-		
+
 		if (testCaseNames == null || testCaseNames.isEmpty()) {
 			this.testCaseNames = new HashSet<>(Arrays.asList(SUCCESS_TEST_CASE));
 		} else {
 			this.testCaseNames = testCaseNames;
 		}
-		
+
 		createTempFile();
-		
+
 		project = new WsdlProject();
 		project.setName(apiName + "_" + apiVersion);
-		
+
 		if (oAuth2Profiles != null) {
 			setAuthProfiles(oAuth2Profiles);
 		}
-		
+
 		restService = (RestService) project.addNewInterface(apiName, RestServiceFactory.REST_TYPE);
 		restService.setDescription(openAPI.getInfo().getDescription());
-		
+
 		setRestServiceEndpoints(openAPI.getServers());
 		setRestServiceResources(openAPI.getPaths());
 		setTestCases();
@@ -188,11 +203,21 @@ public class SoapUIProject {
 	/**
 	 * Set REST Service Endpoints and BasePath
 	 * Iterate OpenAPI servers, extract host part and set as Endpoint
-	 * If REST Service has not basePath, extract from first server item and set it 
+	 * If REST Service has not basePath, extract from first server item and set it
+	 * If serverPattern is set, filter servers to first match or fall back to first server
 	 * @param servers list of servers in OpenAPI
 	 */
 	private void setRestServiceEndpoints(List<Server> servers) {
-		for (Server server : servers) {
+		List<Server> serversToProcess = servers;
+		if (options.getServerPattern() != null && !options.getServerPattern().isBlank()) {
+			Server matched = servers.stream()
+				.filter(s -> s.getUrl().contains(options.getServerPattern()))
+				.findFirst()
+				.orElse(servers.get(0));
+			serversToProcess = List.of(matched);
+		}
+
+		for (Server server : serversToProcess) {
 			String serverUrl = server.getUrl();
 			try {
 				URL url = new URL(serverUrl);
@@ -329,19 +354,28 @@ public class SoapUIProject {
 	 * Set Methods to Resource
 	 * Set Response Representatios (For each Response code and for each media types in response code)
 	 * If has request body set Request Representatios (Media types)
+	 * Skip write operations (POST/PUT/PATCH/DELETE) if readOnly mode is enabled
 	 * @param operations list of path operations
 	 */
 	private void setResourceMethods(RestResource restResource, Map<HttpMethod, Operation> operations) {
 		if (operations != null && !operations.isEmpty()) {
 			operations.forEach((httpMethod, operation) -> {
+				// Feature 1: readOnly
+				if (options.isReadOnly()) {
+					String method = httpMethod.name();
+					if (method.equals("POST") || method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE")) {
+						return;
+					}
+				}
+
 				RestMethod restMethod = restResource.addNewMethod((operation.getOperationId() != null) ? operation.getOperationId() : httpMethod.name());
 				restMethod.setMethod(RestRequestInterface.HttpMethod.valueOf(httpMethod.name()));
 				restMethod.setDescription((operation.getDescription() != null) ? operation.getDescription() : "");
-				
+
 				if (operation.getRequestBody() != null) {
 					setMethodRequestRepresentations(restMethod, operation.getRequestBody());
 				}
-				
+
 				setMethodResponseRepresentations(restMethod, operation.getResponses());
 			});
 		}
@@ -394,37 +428,46 @@ public class SoapUIProject {
 	 * Iterate Operations in OpenAPI Path
 	 * For each Operation, search the Method by operation id or method name
 	 * Create and configure Request and add to Method
+	 * Skip write operations if readOnly mode is enabled
 	 * @param pathName path name to find Resource
 	 * @param pathItem instance of OpenAPI Path to iterate its Operations
 	 */
 	private void setMethodsRequests(String pathName, PathItem pathItem) {
 		RestResource restResource = restService.getResourceByFullPath(restService.getBasePath() + pathName);
-		
+
 		if (restResource != null) {
 			pathItem.readOperationsMap().forEach((httpMethod, operation) -> {
+				// Feature 1: readOnly
+				if (options.isReadOnly()) {
+					String method = httpMethod.name();
+					if (method.equals("POST") || method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE")) {
+						return;
+					}
+				}
+
 				RestMethod restMethod = restResource.getRestMethodByName((operation.getOperationId() != null) ? operation.getOperationId() : httpMethod.name());
 				if (restMethod == null) return;
 				RestRequest restRequest = restMethod.addNewRequest(DEFAULT_REQUEST_NAME);
 				RestRequestConfig restRequestConfig = restRequest.getConfig();
-						
+
 				restRequestConfig.setOriginalUri(restService.getEndpoints()[0] + restResource.getFullPath(true));
 				setRequestAuthProfile(restRequestConfig);
 				setRequestJMSConfig(restRequestConfig);
-				
+
 				restRequest.setEndpoint(restService.getEndpoints()[0]);
 				setRequestMediaType(restRequest, operation);
 
 				setResourceParameters(restResource, pathItem.getParameters());
 				setMethodParameters(restMethod, operation.getParameters());
-				
+
 				if (operation.getRequestBody() != null) {
 					Content content = operation.getRequestBody().getContent();
 					if (content != null && !content.isEmpty()) {
 						setRequestContent(restRequest, content);
 					}
 				}
-				
-				setRequestHeaders(restRequest);
+
+				setRequestHeaders(restRequest, operation);
 			});
 		}
 	}
@@ -432,12 +475,20 @@ public class SoapUIProject {
 	/**
 	 * Set Request Headers
 	 * Iterate headers received in request body and set to Request
+	 * Add Microcks response header if microcksHeaders option is enabled
 	 * @param restRequest instance of Method Request
+	 * @param operation OpenAPI Operation
 	 */
-	private void setRequestHeaders(RestRequest restRequest) {
+	private void setRequestHeaders(RestRequest restRequest, Operation operation) {
+		StringToStringMap requestHeaders = new StringToStringMap();
 		if (headers != null && !headers.isEmpty()) {
-			StringToStringMap requestHeaders = new StringToStringMap();
 			headers.forEach(header -> requestHeaders.put(header.getKey(), header.getValue()));
+		}
+		// Feature 4: microcksHeaders
+		if (options.isMicrocksHeaders() && operation.getOperationId() != null) {
+			requestHeaders.put(MICROCKS_RESPONSE_HEADER_KEY, operation.getOperationId());
+		}
+		if (!requestHeaders.isEmpty()) {
 			restRequest.setRequestHeaders(requestHeaders);
 		}
 	}
@@ -518,15 +569,17 @@ public class SoapUIProject {
 	 * Get property example
 	 * Validate if Property Schema has example, if so, return example value
 	 * If not, return a generic value according to data type
+	 * Feature 5: generateOneOfAnyOf - handle composed schemas
+	 * Feature 6: examples - use custom example values if configured
 	 * @param property
 	 * @param refResolver
 	 * @return
 	 * @throws JSONException
 	 */
 	@SuppressWarnings("rawtypes")
-	private Object getPropertyExample(Schema property, RefResolver refResolver) throws JSONException {		
+	private Object getPropertyExample(Schema property, RefResolver refResolver) throws JSONException {
 		Object example = property.getExample();
-		
+
 		if (example == null) {
 			if (property instanceof ObjectSchema) {
 				example = iterateProperties(((ObjectSchema) property).getProperties(), refResolver);
@@ -536,27 +589,97 @@ public class SoapUIProject {
 				jsonArray.put(getPropertyExample(items, refResolver));
 				example = jsonArray;
 			} else if (property instanceof IntegerSchema) {
-				example = 0;
+				example = getExampleNumber();
 			} else if (property instanceof NumberSchema) {
-				example = 0;
+				example = getExampleNumber();
 			} else if (property instanceof BooleanSchema) {
-				example = true;
+				example = getExampleBoolean();
 			} else if (property instanceof DateSchema) {
-				example = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+				example = getExampleDate();
+			} else if (property instanceof DateTimeSchema) {
+				example = getExampleDateTime();
 			} else if (property instanceof StringSchema) {
 				StringSchema stringProperty = (StringSchema) property;
 				List<String> enums = stringProperty.getEnum();
 				if (enums != null && !enums.isEmpty()) {
 					example = enums.get(0);
 				} else {
-					example = "";
+					example = getExampleString();
 				}
+			} else if (property instanceof ComposedSchema && options.isGenerateOneOfAnyOf()) {
+				// Feature 5: generateOneOfAnyOf
+				ComposedSchema cs = (ComposedSchema) property;
+				List<Schema> candidates = new ArrayList<>();
+				if (cs.getOneOf() != null) candidates.addAll(cs.getOneOf());
+				if (cs.getAnyOf() != null) candidates.addAll(cs.getAnyOf());
+				if (cs.getAllOf() != null) candidates.addAll(cs.getAllOf());
+				Schema<?> chosen = candidates.stream()
+					.map(refResolver::resolveSchema)
+					.filter(s -> s != null)
+					.findFirst()
+					.orElse(null);
+				example = (chosen != null) ? getPropertyExample(chosen, refResolver) : "";
 			} else {
 				example = "";
 			}
 		}
-		
+
 		return example;
+	}
+
+	/**
+	 * Get example number value (feature 6: custom examples)
+	 * @return configured number or 0
+	 */
+	private Object getExampleNumber() {
+		if (options.getExamples() != null && options.getExamples().getSuccessful() != null
+				&& options.getExamples().getSuccessful().getNumber() != null)
+			return options.getExamples().getSuccessful().getNumber();
+		return 0;
+	}
+
+	/**
+	 * Get example boolean value (feature 6: custom examples)
+	 * @return configured boolean or true
+	 */
+	private Object getExampleBoolean() {
+		if (options.getExamples() != null && options.getExamples().getSuccessful() != null
+				&& options.getExamples().getSuccessful().getBooleanValue() != null)
+			return options.getExamples().getSuccessful().getBooleanValue();
+		return true;
+	}
+
+	/**
+	 * Get example date value (feature 6: custom examples)
+	 * @return configured date or today in yyyy-MM-dd format
+	 */
+	private String getExampleDate() {
+		if (options.getExamples() != null && options.getExamples().getSuccessful() != null
+				&& options.getExamples().getSuccessful().getDate() != null)
+			return options.getExamples().getSuccessful().getDate();
+		return new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+	}
+
+	/**
+	 * Get example dateTime value (feature 6: custom examples)
+	 * @return configured dateTime or today in yyyy-MM-dd'T'HH:mm:ss.SSSXXX format
+	 */
+	private String getExampleDateTime() {
+		if (options.getExamples() != null && options.getExamples().getSuccessful() != null
+				&& options.getExamples().getSuccessful().getDateTime() != null)
+			return options.getExamples().getSuccessful().getDateTime();
+		return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(new Date());
+	}
+
+	/**
+	 * Get example string value (feature 6: custom examples)
+	 * @return configured string or empty string
+	 */
+	private String getExampleString() {
+		if (options.getExamples() != null && options.getExamples().getSuccessful() != null
+				&& options.getExamples().getSuccessful().getString() != null)
+			return options.getExamples().getSuccessful().getString();
+		return "";
 	}
 
 	/**
@@ -686,8 +809,14 @@ public class SoapUIProject {
 	 * Iterate SoapUI Project Resources and Methods and add Test Suite for each Method
 	 * Add Test Cases to Test Suite
 	 * Add Test Steps (Request and Groovy Script) to each Test Case
+	 * Feature 3: minimalEndpoints - use only Success_TestCase if enabled
+	 * Feature 7: validateSchema - add Groovy validation step if enabled
 	 */
 	private void setTestCases() {
+		Set<String> effectiveTestCaseNames = options.isMinimalEndpoints()
+			? new HashSet<>(Arrays.asList(SUCCESS_TEST_CASE))
+			: testCaseNames;
+
 		List<RestResource> resources = restService.getAllResources();
 		if (resources != null && !resources.isEmpty()) {
 			resources.forEach(restResource -> {
@@ -697,15 +826,33 @@ public class SoapUIProject {
 						String method = restMethod.getMethod().name();
 						String testSuiteName = restResource.getPath() + "_" + method + "_" + SUITE_SUFFIX;
 						WsdlTestSuite testSuite = project.addNewTestSuite(testSuiteName);
-						for (String testCaseNameItem : testCaseNames) {
+						for (String testCaseNameItem : effectiveTestCaseNames) {
 							String testCaseName = testCaseNameItem + "_" + CASE_SUFFIX;
 							WsdlTestCase testCase = testSuite.addNewTestCase(testCaseName);
 							TestStepConfig ejecutionTestStepConfig = RestRequestStepFactory.createConfig(restMethod.getRequestByName(DEFAULT_REQUEST_NAME), EJECUTION_TEST_STEP + "_" + STEP_SUFFIX);
 							testCase.addTestStep(ejecutionTestStepConfig);
+
+							// Feature 7: validateSchema
+							if (options.isValidateSchema()) {
+								addValidationGroovyStep(testCase);
+							}
 						}
 					});
 				}
 			});
+		}
+	}
+
+	/**
+	 * Add Groovy Script validation step to test case
+	 * Validates that response status code is 2xx
+	 * @param testCase test case to add the step to
+	 */
+	private void addValidationGroovyStep(WsdlTestCase testCase) {
+		com.eviware.soapui.model.testsuite.TestStep groovyStep = testCase.addTestStep(
+			VALIDATE_SCHEMA_GROOVY_TYPE, VALIDATE_SCHEMA_STEP_NAME);
+		if (groovyStep instanceof WsdlGroovyScriptTestStep) {
+			((WsdlGroovyScriptTestStep) groovyStep).setScript(VALIDATE_SCHEMA_GROOVY_SCRIPT);
 		}
 	}
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
@@ -267,10 +267,20 @@ public class SoapUIProject {
 				parameter.setStyle(ParameterStyle.HEADER);
 			} else if (openAPIParameter.getIn().equalsIgnoreCase(PATH)) {
 				parameter.setStyle(ParameterStyle.TEMPLATE);
-			} else if (openAPIParameter.getIn().equalsIgnoreCase(QUERY)) {
+			} else if (openAPIParameter.getIn().equalsIgnoreCase(QUERY) || openAPIParameter.getIn().equalsIgnoreCase("querystring")) {
 				parameter.setStyle(ParameterStyle.QUERY);
 			}
 		}
+	}
+
+	/**
+	 * Determine if an HTTP method should be skipped when readOnly option is enabled.
+	 * @param httpMethod OpenAPI HTTP method
+	 * @return true when method is considered write operation
+	 */
+	private boolean isWriteOperation(HttpMethod httpMethod) {
+		String method = httpMethod.name();
+		return method.equals("POST") || method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE");
 	}
 
 	/**
@@ -361,15 +371,17 @@ public class SoapUIProject {
 		if (operations != null && !operations.isEmpty()) {
 			operations.forEach((httpMethod, operation) -> {
 				// Feature 1: readOnly
-				if (options.isReadOnly()) {
-					String method = httpMethod.name();
-					if (method.equals("POST") || method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE")) {
-						return;
-					}
+				if (options.isReadOnly() && isWriteOperation(httpMethod)) {
+					return;
 				}
 
 				RestMethod restMethod = restResource.addNewMethod((operation.getOperationId() != null) ? operation.getOperationId() : httpMethod.name());
-				restMethod.setMethod(RestRequestInterface.HttpMethod.valueOf(httpMethod.name()));
+				try {
+					restMethod.setMethod(RestRequestInterface.HttpMethod.valueOf(httpMethod.name()));
+				} catch (IllegalArgumentException ex) {
+					log.warn("HTTP method {} is not supported by current SoapUI version and will be skipped", httpMethod.name());
+					return;
+				}
 				restMethod.setDescription((operation.getDescription() != null) ? operation.getDescription() : "");
 
 				if (operation.getRequestBody() != null) {
@@ -438,11 +450,8 @@ public class SoapUIProject {
 		if (restResource != null) {
 			pathItem.readOperationsMap().forEach((httpMethod, operation) -> {
 				// Feature 1: readOnly
-				if (options.isReadOnly()) {
-					String method = httpMethod.name();
-					if (method.equals("POST") || method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE")) {
-						return;
-					}
+				if (options.isReadOnly() && isWriteOperation(httpMethod)) {
+					return;
 				}
 
 				RestMethod restMethod = restResource.getRestMethodByName((operation.getOperationId() != null) ? operation.getOperationId() : httpMethod.name());

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProject.java
@@ -368,29 +368,34 @@ public class SoapUIProject {
 	 * @param operations list of path operations
 	 */
 	private void setResourceMethods(RestResource restResource, Map<HttpMethod, Operation> operations) {
-		if (operations != null && !operations.isEmpty()) {
-			operations.forEach((httpMethod, operation) -> {
-				// Feature 1: readOnly
-				if (options.isReadOnly() && isWriteOperation(httpMethod)) {
-					return;
-				}
-
-				RestMethod restMethod = restResource.addNewMethod((operation.getOperationId() != null) ? operation.getOperationId() : httpMethod.name());
-				try {
-					restMethod.setMethod(RestRequestInterface.HttpMethod.valueOf(httpMethod.name()));
-				} catch (IllegalArgumentException ex) {
-					log.warn("HTTP method {} is not supported by current SoapUI version and will be skipped", httpMethod.name());
-					return;
-				}
-				restMethod.setDescription((operation.getDescription() != null) ? operation.getDescription() : "");
-
-				if (operation.getRequestBody() != null) {
-					setMethodRequestRepresentations(restMethod, operation.getRequestBody());
-				}
-
-				setMethodResponseRepresentations(restMethod, operation.getResponses());
-			});
+		if (operations == null || operations.isEmpty()) {
+			return;
 		}
+		operations.forEach((httpMethod, operation) -> configureResourceMethod(restResource, httpMethod, operation));
+	}
+
+	private void configureResourceMethod(RestResource restResource, HttpMethod httpMethod, Operation operation) {
+		// Feature 1: readOnly
+		if (options.isReadOnly() && isWriteOperation(httpMethod)) {
+			return;
+		}
+
+		String methodName = (operation.getOperationId() != null) ? operation.getOperationId() : httpMethod.name();
+		RestMethod restMethod = restResource.addNewMethod(methodName);
+		try {
+			restMethod.setMethod(RestRequestInterface.HttpMethod.valueOf(httpMethod.name()));
+		} catch (IllegalArgumentException ex) {
+			log.warn("HTTP method {} is not supported by current SoapUI version and will be skipped", httpMethod.name());
+			return;
+		}
+		String description = (operation.getDescription() != null) ? operation.getDescription() : "";
+		restMethod.setDescription(description);
+
+		if (operation.getRequestBody() != null) {
+			setMethodRequestRepresentations(restMethod, operation.getRequestBody());
+		}
+
+		setMethodResponseRepresentations(restMethod, operation.getResponses());
 	}
 
 	/**
@@ -446,38 +451,50 @@ public class SoapUIProject {
 	 */
 	private void setMethodsRequests(String pathName, PathItem pathItem) {
 		RestResource restResource = restService.getResourceByFullPath(restService.getBasePath() + pathName);
+		if (restResource == null) {
+			return;
+		}
+		pathItem.readOperationsMap().forEach((httpMethod, operation) ->
+			configureMethodRequest(restResource, pathItem, httpMethod, operation));
+	}
 
-		if (restResource != null) {
-			pathItem.readOperationsMap().forEach((httpMethod, operation) -> {
-				// Feature 1: readOnly
-				if (options.isReadOnly() && isWriteOperation(httpMethod)) {
-					return;
-				}
+	private void configureMethodRequest(RestResource restResource, PathItem pathItem, HttpMethod httpMethod, Operation operation) {
+		// Feature 1: readOnly
+		if (options.isReadOnly() && isWriteOperation(httpMethod)) {
+			return;
+		}
 
-				RestMethod restMethod = restResource.getRestMethodByName((operation.getOperationId() != null) ? operation.getOperationId() : httpMethod.name());
-				if (restMethod == null) return;
-				RestRequest restRequest = restMethod.addNewRequest(DEFAULT_REQUEST_NAME);
-				RestRequestConfig restRequestConfig = restRequest.getConfig();
+		String methodName = (operation.getOperationId() != null) ? operation.getOperationId() : httpMethod.name();
+		RestMethod restMethod = restResource.getRestMethodByName(methodName);
+		if (restMethod == null) {
+			return;
+		}
 
-				restRequestConfig.setOriginalUri(restService.getEndpoints()[0] + restResource.getFullPath(true));
-				setRequestAuthProfile(restRequestConfig);
-				setRequestJMSConfig(restRequestConfig);
+		RestRequest restRequest = restMethod.addNewRequest(DEFAULT_REQUEST_NAME);
+		RestRequestConfig restRequestConfig = restRequest.getConfig();
 
-				restRequest.setEndpoint(restService.getEndpoints()[0]);
-				setRequestMediaType(restRequest, operation);
+		restRequestConfig.setOriginalUri(restService.getEndpoints()[0] + restResource.getFullPath(true));
+		setRequestAuthProfile(restRequestConfig);
+		setRequestJMSConfig(restRequestConfig);
 
-				setResourceParameters(restResource, pathItem.getParameters());
-				setMethodParameters(restMethod, operation.getParameters());
+		restRequest.setEndpoint(restService.getEndpoints()[0]);
+		setRequestMediaType(restRequest, operation);
 
-				if (operation.getRequestBody() != null) {
-					Content content = operation.getRequestBody().getContent();
-					if (content != null && !content.isEmpty()) {
-						setRequestContent(restRequest, content);
-					}
-				}
+		setResourceParameters(restResource, pathItem.getParameters());
+		setMethodParameters(restMethod, operation.getParameters());
 
-				setRequestHeaders(restRequest, operation);
-			});
+		applyRequestBodyContent(restRequest, operation);
+
+		setRequestHeaders(restRequest, operation);
+	}
+
+	private void applyRequestBodyContent(RestRequest restRequest, Operation operation) {
+		if (operation.getRequestBody() == null) {
+			return;
+		}
+		Content content = operation.getRequestBody().getContent();
+		if (content != null && !content.isEmpty()) {
+			setRequestContent(restRequest, content);
 		}
 	}
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/ExampleSet.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/ExampleSet.java
@@ -1,0 +1,25 @@
+package org.apiaddicts.apitools.openapi2soapui.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ExampleSet {
+
+	@JsonProperty("string")
+	private String string;
+
+	@JsonProperty("number")
+	private Number number;
+
+	@JsonProperty("boolean")
+	private Boolean booleanValue;
+
+	@JsonProperty("date")
+	private String date;
+
+	@JsonProperty("dateTime")
+	private String dateTime;
+}

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/ExampleValues.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/ExampleValues.java
@@ -1,0 +1,19 @@
+package org.apiaddicts.apitools.openapi2soapui.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ExampleValues {
+
+	@Valid
+	@JsonProperty("successful")
+	private ExampleSet successful;
+
+	@Valid
+	@JsonProperty("wrong")
+	private ExampleSet wrong;
+}

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/Header.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/Header.java
@@ -1,6 +1,6 @@
 package org.apiaddicts.apitools.openapi2soapui.request;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/OAuth2Profile.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/OAuth2Profile.java
@@ -1,6 +1,6 @@
 package org.apiaddicts.apitools.openapi2soapui.request;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectOptions.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectOptions.java
@@ -1,0 +1,33 @@
+package org.apiaddicts.apitools.openapi2soapui.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SoapUIProjectOptions {
+
+	@JsonProperty("readOnly")
+	private boolean readOnly = false;
+
+	@JsonProperty("serverPattern")
+	private String serverPattern;
+
+	@JsonProperty("minimalEndpoints")
+	private boolean minimalEndpoints = false;
+
+	@JsonProperty("microcksHeaders")
+	private boolean microcksHeaders = false;
+
+	@JsonProperty("generateOneOfAnyOf")
+	private boolean generateOneOfAnyOf = false;
+
+	@Valid
+	@JsonProperty("examples")
+	private ExampleValues examples;
+
+	@JsonProperty("validateSchema")
+	private boolean validateSchema = false;
+}

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectRequest.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectRequest.java
@@ -37,4 +37,8 @@ public class SoapUIProjectRequest {
 	@Valid
 	@JsonProperty("headers")
 	private List<Header> headers;
+
+	@Valid
+	@JsonProperty("options")
+	private SoapUIProjectOptions options;
 }

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectRequest.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectRequest.java
@@ -3,8 +3,8 @@ package org.apiaddicts.apitools.openapi2soapui.request;
 import java.util.List;
 import java.util.Set;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/service/SoapUIProjectService.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/service/SoapUIProjectService.java
@@ -9,8 +9,9 @@ import io.swagger.v3.oas.models.OpenAPI;
 import org.apiaddicts.apitools.openapi2soapui.model.SoapUIProject;
 import org.apiaddicts.apitools.openapi2soapui.request.OAuth2Profile;
 import org.apiaddicts.apitools.openapi2soapui.request.Header;
+import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
 import org.apache.xmlbeans.XmlException;
 
 public interface SoapUIProjectService {
-    SoapUIProject createSoapUIProject(String apiName, OpenAPI openAPI, List<OAuth2Profile> oAuth2Profiles, List<Header> headers, Set<String> testCases) throws IOException, XmlException, SoapUIException;
+    SoapUIProject createSoapUIProject(String apiName, OpenAPI openAPI, List<OAuth2Profile> oAuth2Profiles, List<Header> headers, Set<String> testCases, SoapUIProjectOptions options) throws IOException, XmlException, SoapUIException;
 }

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/service/SoapUIProjectServiceImpl.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/service/SoapUIProjectServiceImpl.java
@@ -12,14 +12,15 @@ import io.swagger.v3.oas.models.OpenAPI;
 import org.apiaddicts.apitools.openapi2soapui.model.SoapUIProject;
 import org.apiaddicts.apitools.openapi2soapui.request.OAuth2Profile;
 import org.apiaddicts.apitools.openapi2soapui.request.Header;
+import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
 
 @Service
 public class SoapUIProjectServiceImpl implements SoapUIProjectService {
 
 	@Override
 	public SoapUIProject createSoapUIProject(String apiName, OpenAPI openAPI, List<OAuth2Profile> credentials, List<Header> headers,
-			Set<String> testCaseNames) throws IOException, XmlException, SoapUIException {
-		return new SoapUIProject(apiName, openAPI, credentials, headers, testCaseNames);
+			Set<String> testCaseNames, SoapUIProjectOptions options) throws IOException, XmlException, SoapUIException {
+		return new SoapUIProject(apiName, openAPI, credentials, headers, testCaseNames, options);
 	}
 	
 }

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/util/SerializedDataUtils.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/util/SerializedDataUtils.java
@@ -1,6 +1,8 @@
 package org.apiaddicts.apitools.openapi2soapui.util;
 
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apiaddicts.apitools.openapi2soapui.error.exceptions.DecodeBase64Exception;
@@ -19,6 +21,8 @@ import io.swagger.v3.parser.core.models.ParseOptions;
  */
 @Slf4j
 public class SerializedDataUtils {
+	private static final String QUERY = "query";
+	private static final String GET = "get";
 	
 	private SerializedDataUtils() {
 		// Intentional blank
@@ -78,15 +82,102 @@ public class SerializedDataUtils {
 	 */
 	public static OpenAPI parseOpenAPIContent(String openAPIContent) {
 		try {
+			String normalizedContent = normalizeOpenAPI32Content(openAPIContent);
 			ParseOptions parseOptions = new ParseOptions();
 			parseOptions.setResolve(true);
 			parseOptions.setResolveFully(true);
-			OpenAPI openAPI = new OpenAPIParser().readContents(openAPIContent, null, parseOptions).getOpenAPI();
+			OpenAPI openAPI = new OpenAPIParser().readContents(normalizedContent, null, parseOptions).getOpenAPI();
 			validateRequiredOpenAPIProperties(openAPI);
 			return openAPI;
 		} catch (Exception e) {
 			log.info("Error Parsing OpenAPI", e);
 			throw new ParseOpenAPIException(e.getMessage());
+		}
+	}
+
+	/**
+	 * Normalize OpenAPI 3.2 content so it can be parsed by the current parser stack.
+	 * This keeps the runtime compatible while parser-level 3.2 support evolves.
+	 * @param openAPIContent OpenAPI content as string
+	 * @return normalized content for parser consumption
+	 */
+	private static String normalizeOpenAPI32Content(String openAPIContent) {
+		try {
+			Yaml yaml = new Yaml();
+			Object parsed = yaml.load(openAPIContent);
+			if (!(parsed instanceof Map)) {
+				return openAPIContent;
+			}
+
+			Map<String, Object> root = (Map<String, Object>) parsed;
+			Object version = root.get("openapi");
+			if (!(version instanceof String) || !((String) version).startsWith("3.2")) {
+				return openAPIContent;
+			}
+
+			root.put("openapi", "3.1.0");
+			normalizeNode(root);
+			return yaml.dump(root);
+		} catch (Exception e) {
+			log.debug("OpenAPI 3.2 normalization skipped", e);
+			return openAPIContent;
+		}
+	}
+
+	/**
+	 * Recursively normalize known OpenAPI 3.2-only fields to 3.1-compatible fields.
+	 * @param node current structure node
+	 */
+	@SuppressWarnings("unchecked")
+	private static void normalizeNode(Object node) {
+		if (node instanceof Map) {
+			Map<String, Object> map = (Map<String, Object>) node;
+			normalizeParameterLocation(map);
+			normalizeTopLevel32Fields(map);
+			normalizeQueryOperation(map);
+			normalizeComponentsMediaTypes(map);
+			map.values().forEach(SerializedDataUtils::normalizeNode);
+		} else if (node instanceof List) {
+			((List<?>) node).forEach(SerializedDataUtils::normalizeNode);
+		}
+	}
+
+	private static void normalizeParameterLocation(Map<String, Object> map) {
+		Object inValue = map.get("in");
+		if (inValue instanceof String && "querystring".equalsIgnoreCase((String) inValue)) {
+			map.put("in", QUERY);
+		}
+	}
+
+	private static void normalizeTopLevel32Fields(Map<String, Object> map) {
+		if (map.containsKey("$self")) {
+			map.put("x-oas32-self", map.remove("$self"));
+		}
+
+		if (map.containsKey("additionalOperations")) {
+			map.put("x-oas32-additionalOperations", map.remove("additionalOperations"));
+		}
+	}
+
+	private static void normalizeQueryOperation(Map<String, Object> map) {
+		if (map.containsKey(QUERY)) {
+			Object queryOp = map.remove(QUERY);
+			if (!map.containsKey(GET)) {
+				map.put(GET, queryOp);
+			} else {
+				map.put("x-oas32-query-operation", queryOp);
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void normalizeComponentsMediaTypes(Map<String, Object> map) {
+		Object componentsObj = map.get("components");
+		if (componentsObj instanceof Map) {
+			Map<String, Object> components = (Map<String, Object>) componentsObj;
+			if (components.containsKey("mediaTypes")) {
+				components.put("x-oas32-mediaTypes", components.remove("mediaTypes"));
+			}
 		}
 	}
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/util/SerializedDataUtils.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/util/SerializedDataUtils.java
@@ -111,7 +111,7 @@ public class SerializedDataUtils {
 
 			Map<String, Object> root = (Map<String, Object>) parsed;
 			Object version = root.get("openapi");
-			if (!(version instanceof String) || !((String) version).startsWith("3.2")) {
+			if (!(version instanceof String versionStr) || !versionStr.startsWith("3.2")) {
 				return openAPIContent;
 			}
 
@@ -144,7 +144,7 @@ public class SerializedDataUtils {
 
 	private static void normalizeParameterLocation(Map<String, Object> map) {
 		Object inValue = map.get("in");
-		if (inValue instanceof String && "querystring".equalsIgnoreCase((String) inValue)) {
+		if (inValue instanceof String inStr && "querystring".equalsIgnoreCase(inStr)) {
 			map.put("in", QUERY);
 		}
 	}

--- a/src/main/resources/static/api.yaml
+++ b/src/main/resources/static/api.yaml
@@ -453,6 +453,8 @@ components:
             example: Success
         headers:
           $ref: '#/components/schemas/Headers'
+        options:
+          $ref: '#/components/schemas/SoapUIProjectOptions'
     Headers:
       type: array
       description: List of optionals headers. This apply in all resources
@@ -640,3 +642,66 @@ components:
         oneOf:
           - $ref: "#/components/schemas/OAuth2ProfileWithExistingToken"
           - $ref: "#/components/schemas/OAuth2ProfileToGetToken"
+    SoapUIProjectOptions:
+      type: object
+      description: Optional advanced configuration options for SoapUI project generation
+      properties:
+        readOnly:
+          type: boolean
+          default: false
+          description: When true, skip POST/PUT/PATCH/DELETE operations from resources and test suites
+        serverPattern:
+          type: string
+          description: Filter servers by URL substring; uses first match or falls back to first server
+        minimalEndpoints:
+          type: boolean
+          default: false
+          description: When true, generate only the default Success test case per operation
+        microcksHeaders:
+          type: boolean
+          default: false
+          description: When true, add X-Microcks-Response-Name header with operationId value to each request
+        generateOneOfAnyOf:
+          type: boolean
+          default: false
+          description: When true, resolve oneOf/anyOf/allOf schemas to first candidate for example generation
+        examples:
+          $ref: '#/components/schemas/ExampleValues'
+        validateSchema:
+          type: boolean
+          default: false
+          description: When true, add a Groovy script test step validating 2xx response status
+    ExampleValues:
+      type: object
+      description: Custom example values for request body property types
+      properties:
+        successful:
+          $ref: '#/components/schemas/ExampleSet'
+        wrong:
+          $ref: '#/components/schemas/ExampleSet'
+    ExampleSet:
+      type: object
+      description: Per-type example value mappings
+      properties:
+        string:
+          type: string
+          description: Example value for string type properties
+          example: "example"
+        number:
+          type: number
+          description: Example value for number/integer type properties
+          example: 42
+        boolean:
+          type: boolean
+          description: Example value for boolean type properties
+          example: true
+        date:
+          type: string
+          format: date
+          description: Example value for date type properties (yyyy-MM-dd format)
+          example: "2026-04-27"
+        dateTime:
+          type: string
+          format: date-time
+          description: Example value for dateTime type properties
+          example: "2026-04-27T00:00:00.000+00:00"

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/controller/SoapUIProjectControllerFeatureTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/controller/SoapUIProjectControllerFeatureTest.java
@@ -1,0 +1,275 @@
+package org.apiaddicts.apitools.openapi2soapui.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Base64;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SoapUIProjectControllerFeatureTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	private static final String SIMPLE_OPENAPI = "openapi: 3.0.0\n" +
+		"info:\n" +
+		"  title: Test API\n" +
+		"  version: 1.0.0\n" +
+		"servers:\n" +
+		"  - url: http://api.example.com/v1\n" +
+		"    description: Production\n" +
+		"  - url: http://staging.example.com/v1\n" +
+		"    description: Staging\n" +
+		"paths:\n" +
+		"  /users:\n" +
+		"    get:\n" +
+		"      operationId: listUsers\n" +
+		"      responses:\n" +
+		"        '200':\n" +
+		"          description: Success\n" +
+		"          content:\n" +
+		"            application/json:\n" +
+		"              schema:\n" +
+		"                type: array\n" +
+		"    post:\n" +
+		"      operationId: createUser\n" +
+		"      requestBody:\n" +
+		"        content:\n" +
+		"          application/json:\n" +
+		"            schema:\n" +
+		"              type: object\n" +
+		"      responses:\n" +
+		"        '201':\n" +
+		"          description: Created\n" +
+		"          content:\n" +
+		"            application/json:\n" +
+		"              schema:\n" +
+		"                type: object\n";
+
+	@Test
+	void testReadOnlyFeature() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\",\n" +
+			"  \"options\": {\n" +
+			"    \"readOnly\": true\n" +
+			"  }\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+			.andExpect(result -> {
+				String response = result.getResponse().getContentAsString();
+				// POST method should not be included when readOnly is true
+				assert response.contains("GET");
+				assert !response.contains("POST");
+			});
+	}
+
+	@Test
+	void testServerPatternFeature() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\",\n" +
+			"  \"options\": {\n" +
+			"    \"serverPattern\": \"staging\"\n" +
+			"  }\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+			.andExpect(result -> {
+				String response = result.getResponse().getContentAsString();
+				// Should contain staging server
+				assert response.contains("staging.example.com");
+			});
+	}
+
+	@Test
+	void testMinimalEndpointsFeature() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\",\n" +
+			"  \"testCaseNames\": [\"Success\", \"ErrorCase\"],\n" +
+			"  \"options\": {\n" +
+			"    \"minimalEndpoints\": true\n" +
+			"  }\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+			.andExpect(result -> {
+				String response = result.getResponse().getContentAsString();
+				// Should only have Success_TestCase, not ErrorCase_TestCase
+				assert response.contains("Success_TestCase");
+				assert !response.contains("ErrorCase_TestCase");
+			});
+	}
+
+	@Test
+	void testMicrocksHeadersFeature() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\",\n" +
+			"  \"options\": {\n" +
+			"    \"microcksHeaders\": true\n" +
+			"  }\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+			.andExpect(result -> {
+				String response = result.getResponse().getContentAsString();
+				// Should contain X-Microcks-Response-Name header
+				assert response.contains("X-Microcks-Response-Name");
+				assert response.contains("listUsers") || response.contains("createUser");
+			});
+	}
+
+	@Test
+	void testValidateSchemaFeature() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\",\n" +
+			"  \"options\": {\n" +
+			"    \"validateSchema\": true\n" +
+			"  }\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+			.andExpect(result -> {
+				String response = result.getResponse().getContentAsString();
+				// Should contain Validation_TestStep for Groovy script
+				assert response.contains("Validation_TestStep");
+				assert response.contains("groovy");
+			});
+	}
+
+	@Test
+	void testCustomExamplesFeature() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\",\n" +
+			"  \"options\": {\n" +
+			"    \"examples\": {\n" +
+			"      \"successful\": {\n" +
+			"        \"string\": \"custom_value\",\n" +
+			"        \"number\": 99,\n" +
+			"        \"boolean\": false,\n" +
+			"        \"date\": \"2025-12-31\",\n" +
+			"        \"dateTime\": \"2025-12-31T23:59:59.000+00:00\"\n" +
+			"      }\n" +
+			"    }\n" +
+			"  }\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
+	}
+
+	@Test
+	void testMultipleOptionsEnabled() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\",\n" +
+			"  \"options\": {\n" +
+			"    \"readOnly\": true,\n" +
+			"    \"serverPattern\": \"staging\",\n" +
+			"    \"microcksHeaders\": true,\n" +
+			"    \"validateSchema\": true\n" +
+			"  }\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+			.andExpect(result -> {
+				String response = result.getResponse().getContentAsString();
+				// Should have all features
+				assert response.contains("staging.example.com");
+				assert !response.contains("POST");
+				assert response.contains("X-Microcks-Response-Name");
+				assert response.contains("Validation_TestStep");
+			});
+	}
+
+	@Test
+	void testNullOptionsHandling() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\"\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+			.andExpect(result -> {
+				String response = result.getResponse().getContentAsString();
+				// Should behave like default (includes POST, etc.)
+				assert response.contains("POST");
+				assert response.contains("GET");
+			});
+	}
+
+	@Test
+	void testEmptyOptionsHandling() throws Exception {
+		String encodedSpec = Base64.getEncoder().encodeToString(SIMPLE_OPENAPI.getBytes());
+		String requestBody = "{\n" +
+			"  \"apiName\": \"TestAPI\",\n" +
+			"  \"openApiSpec\": \"" + encodedSpec + "\",\n" +
+			"  \"options\": {}\n" +
+			"}";
+
+		mockMvc.perform(post("/api-openapi-to-soapui/v1/soap-ui-projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+			.andExpect(result -> {
+				String response = result.getResponse().getContentAsString();
+				// Should behave like default
+				assert response.contains("POST");
+				assert response.contains("GET");
+			});
+	}
+}

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/EdgeCaseTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/EdgeCaseTest.java
@@ -1,0 +1,414 @@
+package org.apiaddicts.apitools.openapi2soapui.integration;
+
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.apiaddicts.apitools.openapi2soapui.model.SoapUIProject;
+import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
+import com.eviware.soapui.support.SoapUIException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Edge Case and Error Handling Tests")
+class EdgeCaseTest {
+
+	private final OpenAPIV3Parser parser = new OpenAPIV3Parser();
+
+	@Nested
+	@DisplayName("Minimal/Empty Specs")
+	class MinimalSpecs {
+
+		@Test
+		@DisplayName("Should handle minimal valid spec with single endpoint")
+		void testMinimalSpec() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Minimal\n" +
+				"  version: 1.0\n" +
+				"servers:\n" +
+				"  - url: http://localhost\n" +
+				"paths:\n" +
+				"  /test:\n" +
+				"    get:\n" +
+				"      operationId: test\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "Should parse minimal spec");
+
+			SoapUIProject project = new SoapUIProject("Minimal", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("test"), "Should generate valid project");
+		}
+	}
+
+	@Nested
+	@DisplayName("Special Characters and Encoding")
+	class SpecialCharacters {
+
+		@Test
+		@DisplayName("Should handle special characters in operation names")
+		void testSpecialCharactersInNames() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Special Chars API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    post:\n" +
+				"      operationId: createUser\n" +
+				"      summary: Create a new user (with 'special' chars)\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: User created successfully\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("SpecialCharsAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("createUser"), "Should handle operation with special chars");
+		}
+
+		@Test
+		@DisplayName("Should handle Unicode characters in descriptions")
+		void testUnicodeCharacters() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Unicode API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    get:\n" +
+				"      operationId: getUsers\n" +
+				"      summary: Get users (获取用户)\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Success (成功)\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("UnicodeAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getUsers"), "Should handle Unicode characters");
+		}
+	}
+
+	@Nested
+	@DisplayName("Large and Complex Specs")
+	class LargeAndComplexSpecs {
+
+		@Test
+		@DisplayName("Should handle spec with many endpoints")
+		void testManyEndpoints() throws IOException, XmlException, SoapUIException {
+			StringBuilder spec = new StringBuilder("openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Many Endpoints API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n");
+
+			// Generate 20 endpoints
+			for (int i = 1; i <= 20; i++) {
+				spec.append("  /endpoint").append(i).append(":\n");
+				spec.append("    get:\n");
+				spec.append("      operationId: endpoint").append(i).append("\n");
+				spec.append("      responses:\n");
+				spec.append("        '200':\n");
+				spec.append("          description: OK\n");
+			}
+
+			OpenAPI openAPI = parser.readContents(spec.toString()).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("ManyEndpointsAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 5000, "Should handle many endpoints");
+			for (int i = 1; i <= 20; i++) {
+				assertTrue(xml.contains("endpoint" + i), "Should contain endpoint" + i);
+			}
+		}
+
+		@Test
+		@DisplayName("Should handle deeply nested schemas")
+		void testDeeplyNestedSchemas() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Deeply Nested API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    post:\n" +
+				"      operationId: post\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                level1:\n" +
+				"                  type: object\n" +
+				"                  properties:\n" +
+				"                    level2:\n" +
+				"                      type: object\n" +
+				"                      properties:\n" +
+				"                        level3:\n" +
+				"                          type: object\n" +
+				"                          properties:\n" +
+				"                            level4:\n" +
+				"                              type: object\n" +
+				"                              properties:\n" +
+				"                                level5:\n" +
+				"                                  type: object\n" +
+				"                                  properties:\n" +
+				"                                    value:\n" +
+				"                                      type: string\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("DeeplyNestedAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 1000, "Should handle deeply nested structures");
+		}
+	}
+
+	@Nested
+	@DisplayName("Response Code Variations")
+	class ResponseCodeVariations {
+
+		@Test
+		@DisplayName("Should handle various HTTP response codes")
+		void testVariousResponseCodes() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Response Codes API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    get:\n" +
+				"      operationId: getData\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"        '201':\n" +
+				"          description: Created\n" +
+				"        '204':\n" +
+				"          description: No Content\n" +
+				"        '301':\n" +
+				"          description: Moved Permanently\n" +
+				"        '304':\n" +
+				"          description: Not Modified\n" +
+				"        '400':\n" +
+				"          description: Bad Request\n" +
+				"        '401':\n" +
+				"          description: Unauthorized\n" +
+				"        '403':\n" +
+				"          description: Forbidden\n" +
+				"        '404':\n" +
+				"          description: Not Found\n" +
+				"        '500':\n" +
+				"          description: Internal Server Error\n" +
+				"        '503':\n" +
+				"          description: Service Unavailable\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("ResponseCodesAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getData"), "Should contain operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("Empty/Null Options Handling")
+	class OptionsHandling {
+
+		@Test
+		@DisplayName("Should handle null options gracefully")
+		void testNullOptions() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Test\n" +
+				"  version: 1.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /test:\n" +
+				"    get:\n" +
+				"      operationId: test\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("test"), "Should handle null options");
+		}
+
+		@Test
+		@DisplayName("Should handle empty options object")
+		void testEmptyOptions() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Test\n" +
+				"  version: 1.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /test:\n" +
+				"    get:\n" +
+				"      operationId: test\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+
+			SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("test"), "Should handle empty options");
+		}
+	}
+
+	@Nested
+	@DisplayName("Path Variations")
+	class PathVariations {
+
+		@Test
+		@DisplayName("Should handle root path")
+		void testRootPath() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Root Path API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /:\n" +
+				"    get:\n" +
+				"      operationId: root\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("RootPathAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("root"), "Should handle root path");
+		}
+
+		@Test
+		@DisplayName("Should handle paths with multiple path parameters")
+		void testComplexPathStructure() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Complex Path API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /v1/orgs/{orgId}/teams/{teamId}/members/{memberId}/permissions:\n" +
+				"    get:\n" +
+				"      operationId: getPermissions\n" +
+				"      parameters:\n" +
+				"        - name: orgId\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: teamId\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: memberId\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Permissions\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("ComplexPathAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getPermissions"), "Should handle complex path");
+		}
+	}
+
+	@Nested
+	@DisplayName("Content Type Variations")
+	class ContentTypeVariations {
+
+		@Test
+		@DisplayName("Should handle multiple response content types")
+		void testMultipleResponseContentTypes() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Multi Response Content API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    get:\n" +
+				"      operationId: getData\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Success\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n" +
+				"            application/xml:\n" +
+				"              schema:\n" +
+				"                type: object\n" +
+				"            text/plain:\n" +
+				"              schema:\n" +
+				"                type: string\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("MultiResponseAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getData"), "Should handle multiple response content types");
+		}
+	}
+}

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/EndToEndGenerationTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/EndToEndGenerationTest.java
@@ -1,0 +1,441 @@
+package org.apiaddicts.apitools.openapi2soapui.integration;
+
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.apiaddicts.apitools.openapi2soapui.model.SoapUIProject;
+import org.apiaddicts.apitools.openapi2soapui.request.ExampleSet;
+import org.apiaddicts.apitools.openapi2soapui.request.ExampleValues;
+import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
+import com.eviware.soapui.support.SoapUIException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("End-to-End SoapUI Project Generation Tests")
+class EndToEndGenerationTest {
+
+	private final OpenAPIV3Parser parser = new OpenAPIV3Parser();
+
+	@Nested
+	@DisplayName("Simple API Generation")
+	class SimpleAPIGeneration {
+
+		@Test
+		@DisplayName("Should generate SoapUI project from minimal OpenAPI spec")
+		void testMinimalSpec() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Minimal API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /ping:\n" +
+				"    get:\n" +
+				"      operationId: ping\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Pong\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("MinimalAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("MinimalAPI"), "Should contain API name");
+			assertTrue(xml.contains("ping"), "Should contain operation");
+			assertTrue(xml.contains("http://api.example.com"), "Should contain server URL");
+		}
+
+		@Test
+		@DisplayName("Should handle single endpoint with GET method")
+		void testSingleGETEndpoint() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: GET API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: https://api.example.com/v1\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    get:\n" +
+				"      operationId: listUsers\n" +
+				"      summary: List all users\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: User list\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: array\n" +
+				"                items:\n" +
+				"                  type: object\n" +
+				"                  properties:\n" +
+				"                    id:\n" +
+				"                      type: integer\n" +
+				"                    name:\n" +
+				"                      type: string\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("GetAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 1000, "Should generate substantial XML");
+			assertTrue(xml.contains("listUsers"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle multiple endpoints with different HTTP methods")
+		void testMultipleEndpoints() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: CRUD API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: getItems\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    post:\n" +
+				"      operationId: createItem\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n" +
+				"  /items/{id}:\n" +
+				"    get:\n" +
+				"      operationId: getItem\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    put:\n" +
+				"      operationId: updateItem\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    delete:\n" +
+				"      operationId: deleteItem\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '204':\n" +
+				"          description: Deleted\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("CrudAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getItems"), "Should contain GET operation");
+			assertTrue(xml.contains("createItem"), "Should contain POST operation");
+			assertTrue(xml.contains("updateItem"), "Should contain PUT operation");
+			assertTrue(xml.contains("deleteItem"), "Should contain DELETE operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("Complex API Generation")
+	class ComplexAPIGeneration {
+
+		@Test
+		@DisplayName("Should handle nested request/response bodies")
+		void testNestedBodies() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Nested API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /orders:\n" +
+				"    post:\n" +
+				"      operationId: createOrder\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                customer:\n" +
+				"                  type: object\n" +
+				"                  properties:\n" +
+				"                    name:\n" +
+				"                      type: string\n" +
+				"                    address:\n" +
+				"                      type: object\n" +
+				"                      properties:\n" +
+				"                        street:\n" +
+				"                          type: string\n" +
+				"                        city:\n" +
+				"                          type: string\n" +
+				"                items:\n" +
+				"                  type: array\n" +
+				"                  items:\n" +
+				"                    type: object\n" +
+				"                    properties:\n" +
+				"                      id:\n" +
+				"                        type: integer\n" +
+				"                      quantity:\n" +
+				"                        type: integer\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Order created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("NestedAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("createOrder"), "Should contain operation");
+			assertTrue(xml.length() > 2000, "Should generate substantial XML for nested structure");
+		}
+
+		@Test
+		@DisplayName("Should handle multiple servers")
+		void testMultipleServers() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Multi-Server API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://dev.api.example.com\n" +
+				"    description: Development\n" +
+				"  - url: http://staging.api.example.com\n" +
+				"    description: Staging\n" +
+				"  - url: http://api.example.com\n" +
+				"    description: Production\n" +
+				"paths:\n" +
+				"  /health:\n" +
+				"    get:\n" +
+				"      operationId: health\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("MultiServerAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("dev.api.example.com") || xml.contains("staging.api.example.com") ||
+				xml.contains("api.example.com"), "Should contain at least one server");
+		}
+
+		@Test
+		@DisplayName("Should handle multiple content types")
+		void testMultipleContentTypes() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Multi-Content API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    post:\n" +
+				"      operationId: postData\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"          application/xml:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"          application/form-urlencoded:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n" +
+				"            application/xml:\n" +
+				"              schema:\n" +
+				"                type: object\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("MultiContentAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should handle multiple content types");
+		}
+	}
+
+	@Nested
+	@DisplayName("Feature Integration Tests")
+	class FeatureIntegration {
+
+		@Test
+		@DisplayName("Should apply readOnly to complex API")
+		void testReadOnlyOnComplexAPI() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Complex API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    get:\n" +
+				"      operationId: getData\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    post:\n" +
+				"      operationId: postData\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n" +
+				"    put:\n" +
+				"      operationId: putData\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    delete:\n" +
+				"      operationId: deleteData\n" +
+				"      responses:\n" +
+				"        '204':\n" +
+				"          description: Deleted\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+			options.setReadOnly(true);
+
+			SoapUIProject project = new SoapUIProject("ComplexAPI", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getData"), "Should include GET");
+			assertFalse(xml.contains("postData"), "Should exclude POST");
+			assertFalse(xml.contains("putData"), "Should exclude PUT");
+			assertFalse(xml.contains("deleteData"), "Should exclude DELETE");
+		}
+
+		@Test
+		@DisplayName("Should apply custom examples to requests")
+		void testCustomExamplesOnComplexAPI() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Examples API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    post:\n" +
+				"      operationId: createUser\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                age:\n" +
+				"                  type: integer\n" +
+				"                active:\n" +
+				"                  type: boolean\n" +
+				"                joinDate:\n" +
+				"                  type: string\n" +
+				"                  format: date\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			ExampleSet examples = new ExampleSet();
+			examples.setNumber(30);
+			examples.setBooleanValue(true);
+			examples.setDate("2025-06-15");
+
+			ExampleValues exampleValues = new ExampleValues();
+			exampleValues.setSuccessful(examples);
+
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+			options.setExamples(exampleValues);
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("ExamplesAPI", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("createUser"), "Should contain operation");
+			assertTrue(xml.length() > 0, "Should generate valid XML");
+		}
+
+		@Test
+		@DisplayName("Should combine multiple features")
+		void testMultipleFeaturesOnAPI() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Multi-Feature API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://prod.api.example.com\n" +
+				"  - url: http://staging.api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: listItems\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    post:\n" +
+				"      operationId: createItem\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			ExampleSet examples = new ExampleSet();
+			examples.setString("test-value");
+
+			ExampleValues exampleValues = new ExampleValues();
+			exampleValues.setSuccessful(examples);
+
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+			options.setReadOnly(true);
+			options.setServerPattern("staging");
+			options.setMicrocksHeaders(true);
+			options.setExamples(exampleValues);
+			options.setValidateSchema(true);
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("MultiFeatureAPI", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("listItems"), "Should include GET");
+			assertFalse(xml.contains("createItem"), "Should exclude POST with readOnly");
+			assertTrue(xml.contains("staging.api.example.com"), "Should use staging server");
+			assertTrue(xml.contains("Validation_TestStep"), "Should include validation step");
+		}
+	}
+}

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/HTTPMethodHandlingTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/HTTPMethodHandlingTest.java
@@ -1,0 +1,396 @@
+package org.apiaddicts.apitools.openapi2soapui.integration;
+
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.apiaddicts.apitools.openapi2soapui.model.SoapUIProject;
+import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
+import com.eviware.soapui.support.SoapUIException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("HTTP Method Handling Tests")
+class HTTPMethodHandlingTest {
+
+	private final OpenAPIV3Parser parser = new OpenAPIV3Parser();
+
+	@Nested
+	@DisplayName("Standard HTTP Methods")
+	class StandardMethods {
+
+		@Test
+		@DisplayName("Should handle GET requests")
+		void testGETMethod() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: GET API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: getItems\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("GETAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getItems"), "Should contain GET operation");
+		}
+
+		@Test
+		@DisplayName("Should handle POST requests with request body")
+		void testPOSTMethod() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: POST API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    post:\n" +
+				"      operationId: createItem\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                name:\n" +
+				"                  type: string\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("POSTAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("createItem"), "Should contain POST operation");
+		}
+
+		@Test
+		@DisplayName("Should handle PUT requests")
+		void testPUTMethod() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: PUT API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items/{id}:\n" +
+				"    put:\n" +
+				"      operationId: updateItem\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Updated\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("PUTAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("updateItem"), "Should contain PUT operation");
+		}
+
+		@Test
+		@DisplayName("Should handle PATCH requests")
+		void testPATCHMethod() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: PATCH API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items/{id}:\n" +
+				"    patch:\n" +
+				"      operationId: patchItem\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Patched\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("PATCHAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("patchItem"), "Should contain PATCH operation");
+		}
+
+		@Test
+		@DisplayName("Should handle DELETE requests")
+		void testDELETEMethod() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: DELETE API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items/{id}:\n" +
+				"    delete:\n" +
+				"      operationId: deleteItem\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '204':\n" +
+				"          description: Deleted\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("DELETEAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("deleteItem"), "Should contain DELETE operation");
+		}
+
+		@Test
+		@DisplayName("Should handle HEAD requests")
+		void testHEADMethod() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: HEAD API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    head:\n" +
+				"      operationId: headItems\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("HEADAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should generate valid XML for HEAD request");
+		}
+
+		@Test
+		@DisplayName("Should handle OPTIONS requests")
+		void testOPTIONSMethod() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: OPTIONS API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    options:\n" +
+				"      operationId: optionsItems\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("OPTIONSAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should generate valid XML for OPTIONS request");
+		}
+	}
+
+	@Nested
+	@DisplayName("Multiple Methods on Same Path")
+	class MultipleMethods {
+
+		@Test
+		@DisplayName("Should handle all CRUD methods on same endpoint")
+		void testCRUDMethods() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: CRUD API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: list\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n" +
+				"  /items/{id}:\n" +
+				"    get:\n" +
+				"      operationId: read\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    put:\n" +
+				"      operationId: update\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Updated\n" +
+				"    delete:\n" +
+				"      operationId: delete\n" +
+				"      parameters:\n" +
+				"        - name: id\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '204':\n" +
+				"          description: Deleted\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("CrudAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("list"), "Should contain list");
+			assertTrue(xml.contains("create"), "Should contain create");
+			assertTrue(xml.contains("read"), "Should contain read");
+			assertTrue(xml.contains("update"), "Should contain update");
+			assertTrue(xml.contains("delete"), "Should contain delete");
+		}
+	}
+
+	@Nested
+	@DisplayName("Method Filtering with readOnly")
+	class MethodFiltering {
+
+		@Test
+		@DisplayName("readOnly should exclude only write methods")
+		void testReadOnlyFiltering() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Filter API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    get:\n" +
+				"      operationId: read1\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    head:\n" +
+				"      operationId: head1\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    options:\n" +
+				"      operationId: options1\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    post:\n" +
+				"      operationId: write1\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n" +
+				"    put:\n" +
+				"      operationId: write2\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    patch:\n" +
+				"      operationId: write3\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    delete:\n" +
+				"      operationId: write4\n" +
+				"      responses:\n" +
+				"        '204':\n" +
+				"          description: Deleted\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+			options.setReadOnly(true);
+
+			SoapUIProject project = new SoapUIProject("FilterAPI", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("read1"), "Should include GET");
+			assertFalse(xml.contains("write1"), "Should exclude POST");
+			assertFalse(xml.contains("write2"), "Should exclude PUT");
+			assertFalse(xml.contains("write3"), "Should exclude PATCH");
+			assertFalse(xml.contains("write4"), "Should exclude DELETE");
+		}
+
+		@Test
+		@DisplayName("readOnly should work with single read-only endpoint")
+		void testReadOnlyWithSingleGET() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: ReadOnly API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /status:\n" +
+				"    get:\n" +
+				"      operationId: status\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+			options.setReadOnly(true);
+
+			SoapUIProject project = new SoapUIProject("ReadOnlyAPI", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("status"), "Should include GET operation");
+		}
+	}
+}

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/ParameterHandlingTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/ParameterHandlingTest.java
@@ -1,0 +1,392 @@
+package org.apiaddicts.apitools.openapi2soapui.integration;
+
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.apiaddicts.apitools.openapi2soapui.model.SoapUIProject;
+import com.eviware.soapui.support.SoapUIException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Parameter Handling Tests")
+class ParameterHandlingTest {
+
+	private final OpenAPIV3Parser parser = new OpenAPIV3Parser();
+
+	@Nested
+	@DisplayName("Path Parameters")
+	class PathParameters {
+
+		@Test
+		@DisplayName("Should handle single path parameter")
+		void testSinglePathParameter() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Path Param API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users/{userId}:\n" +
+				"    get:\n" +
+				"      operationId: getUser\n" +
+				"      parameters:\n" +
+				"        - name: userId\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: User\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("PathParamAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getUser"), "Should contain operation");
+			assertTrue(xml.length() > 0, "Should generate valid XML");
+		}
+
+		@Test
+		@DisplayName("Should handle multiple path parameters")
+		void testMultiplePathParameters() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Multi Path Param API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /organizations/{orgId}/projects/{projectId}/members/{memberId}:\n" +
+				"    get:\n" +
+				"      operationId: getMember\n" +
+				"      parameters:\n" +
+				"        - name: orgId\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: projectId\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: memberId\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Member\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("MultiPathAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getMember"), "Should contain operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("Query Parameters")
+	class QueryParameters {
+
+		@Test
+		@DisplayName("Should handle single query parameter")
+		void testSingleQueryParameter() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Query Param API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    get:\n" +
+				"      operationId: listUsers\n" +
+				"      parameters:\n" +
+				"        - name: limit\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Users\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("QueryParamAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("listUsers"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle multiple query parameters")
+		void testMultipleQueryParameters() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Multi Query API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    get:\n" +
+				"      operationId: search\n" +
+				"      parameters:\n" +
+				"        - name: search\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: limit\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"        - name: offset\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"        - name: sortBy\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Users\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("MultiQueryAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("search"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle required and optional query parameters")
+		void testRequiredAndOptionalParameters() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Required Param API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /search:\n" +
+				"    get:\n" +
+				"      operationId: search\n" +
+				"      parameters:\n" +
+				"        - name: q\n" +
+				"          in: query\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: filter\n" +
+				"          in: query\n" +
+				"          required: false\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Results\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("RequiredParamAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("search"), "Should contain operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("Header Parameters")
+	class HeaderParameters {
+
+		@Test
+		@DisplayName("Should handle header parameters")
+		void testHeaderParameters() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Header API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    get:\n" +
+				"      operationId: getData\n" +
+				"      parameters:\n" +
+				"        - name: X-API-Key\n" +
+				"          in: header\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: Accept-Language\n" +
+				"          in: header\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Data\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("HeaderAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getData"), "Should contain operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("Mixed Parameter Types")
+	class MixedParameters {
+
+		@Test
+		@DisplayName("Should handle path, query, and header parameters together")
+		void testMixedParameters() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Mixed Param API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /orgs/{orgId}/repos:\n" +
+				"    get:\n" +
+				"      operationId: listRepos\n" +
+				"      parameters:\n" +
+				"        - name: orgId\n" +
+				"          in: path\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: type\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"            enum: [all, owner, member]\n" +
+				"        - name: sort\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: Authorization\n" +
+				"          in: header\n" +
+				"          required: true\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Repositories\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("MixedParamAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("listRepos"), "Should contain operation");
+			assertTrue(xml.length() > 1000, "Should generate substantial XML");
+		}
+	}
+
+	@Nested
+	@DisplayName("Parameter Data Types")
+	class ParameterDataTypes {
+
+		@Test
+		@DisplayName("Should handle various parameter data types")
+		void testParameterDataTypes() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Data Type API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: search\n" +
+				"      parameters:\n" +
+				"        - name: stringParam\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"        - name: intParam\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"        - name: numberParam\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: number\n" +
+				"        - name: boolParam\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: boolean\n" +
+				"        - name: dateParam\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"            format: date\n" +
+				"        - name: dateTimeParam\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: string\n" +
+				"            format: date-time\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Results\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("DataTypeAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("search"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle array parameters")
+		void testArrayParameters() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Array Param API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: filter\n" +
+				"      parameters:\n" +
+				"        - name: tags\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: array\n" +
+				"            items:\n" +
+				"              type: string\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Items\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("ArrayParamAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("filter"), "Should contain operation");
+		}
+	}
+}

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/SchemaHandlingTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/integration/SchemaHandlingTest.java
@@ -1,0 +1,431 @@
+package org.apiaddicts.apitools.openapi2soapui.integration;
+
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.apiaddicts.apitools.openapi2soapui.model.SoapUIProject;
+import com.eviware.soapui.support.SoapUIException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Schema Handling Tests")
+class SchemaHandlingTest {
+
+	private final OpenAPIV3Parser parser = new OpenAPIV3Parser();
+
+	@Nested
+	@DisplayName("Basic Data Types")
+	class BasicDataTypes {
+
+		@Test
+		@DisplayName("Should handle string schema")
+		void testStringSchema() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: String Schema API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: string\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("StringAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle numeric schemas")
+		void testNumericSchemas() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Numeric Schema API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                count:\n" +
+				"                  type: integer\n" +
+				"                price:\n" +
+				"                  type: number\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("NumericAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle boolean schema")
+		void testBooleanSchema() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Boolean Schema API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /toggle:\n" +
+				"    post:\n" +
+				"      operationId: toggle\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                enabled:\n" +
+				"                  type: boolean\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Updated\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("BooleanAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("toggle"), "Should contain operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("Complex Schemas")
+	class ComplexSchemas {
+
+		@Test
+		@DisplayName("Should handle nested objects")
+		void testNestedObjects() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Nested API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                name:\n" +
+				"                  type: string\n" +
+				"                profile:\n" +
+				"                  type: object\n" +
+				"                  properties:\n" +
+				"                    bio:\n" +
+				"                      type: string\n" +
+				"                    avatar:\n" +
+				"                      type: object\n" +
+				"                      properties:\n" +
+				"                        url:\n" +
+				"                          type: string\n" +
+				"                        size:\n" +
+				"                          type: integer\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("NestedAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+			assertTrue(xml.length() > 2000, "Should generate substantial XML");
+		}
+
+		@Test
+		@DisplayName("Should handle array schemas")
+		void testArraySchemas() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Array API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: array\n" +
+				"              items:\n" +
+				"                type: object\n" +
+				"                properties:\n" +
+				"                  id:\n" +
+				"                    type: integer\n" +
+				"                  name:\n" +
+				"                    type: string\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("ArrayAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle schema composition with allOf")
+		void testAllOfComposition() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: AllOf API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              allOf:\n" +
+				"                - type: object\n" +
+				"                  properties:\n" +
+				"                    id:\n" +
+				"                      type: integer\n" +
+				"                - type: object\n" +
+				"                  properties:\n" +
+				"                    name:\n" +
+				"                      type: string\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("AllOfAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("Schema Constraints")
+	class SchemaConstraints {
+
+		@Test
+		@DisplayName("Should handle enum values")
+		void testEnumValues() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Enum API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /orders:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                status:\n" +
+				"                  type: string\n" +
+				"                  enum: [pending, confirmed, shipped, delivered]\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("EnumAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle min/max constraints")
+		void testMinMaxConstraints() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Constraint API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                quantity:\n" +
+				"                  type: integer\n" +
+				"                  minimum: 1\n" +
+				"                  maximum: 100\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("ConstraintAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("Format Handling")
+	class FormatHandling {
+
+		@Test
+		@DisplayName("Should handle date format")
+		void testDateFormat() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Date Format API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /events:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                eventDate:\n" +
+				"                  type: string\n" +
+				"                  format: date\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("DateFormatAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle date-time format")
+		void testDateTimeFormat() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: DateTime Format API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /events:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                timestamp:\n" +
+				"                  type: string\n" +
+				"                  format: date-time\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("DateTimeAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle email format")
+		void testEmailFormat() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Email Format API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    post:\n" +
+				"      operationId: create\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                email:\n" +
+				"                  type: string\n" +
+				"                  format: email\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("EmailFormatAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("create"), "Should contain operation");
+		}
+	}
+}

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/model/OpenAPIVersionSupportTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/model/OpenAPIVersionSupportTest.java
@@ -1,0 +1,563 @@
+package org.apiaddicts.apitools.openapi2soapui.model;
+
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
+import com.eviware.soapui.support.SoapUIException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("OpenAPI Version Support Tests")
+class OpenAPIVersionSupportTest {
+
+	private final OpenAPIV3Parser parser = new OpenAPIV3Parser();
+
+	@Nested
+	@DisplayName("OpenAPI 3.0.x Support")
+	class OpenAPI30Support {
+
+		@Test
+		@DisplayName("Should parse OpenAPI 3.0.0 spec")
+		void testParseOpenAPI30() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Test API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com/v1\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    get:\n" +
+				"      operationId: listUsers\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n" +
+				"                properties:\n" +
+				"                  id:\n" +
+				"                    type: integer\n" +
+				"                  name:\n" +
+				"                    type: string\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "OpenAPI 3.0.0 spec should parse successfully");
+			assertEquals("3.0.0", openAPI.getOpenapi(), "Should detect OpenAPI version 3.0.0");
+
+			SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("listUsers"), "Generated XML should contain operation");
+			assertTrue(xml.contains("TestAPI"), "Generated XML should contain API name");
+		}
+
+		@Test
+		@DisplayName("Should parse OpenAPI 3.0.3 spec")
+		void testParseOpenAPI303() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.3\n" +
+				"info:\n" +
+				"  title: Products API\n" +
+				"  version: 2.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /products:\n" +
+				"    get:\n" +
+				"      operationId: getProducts\n" +
+				"      parameters:\n" +
+				"        - name: limit\n" +
+				"          in: query\n" +
+				"          schema:\n" +
+				"            type: integer\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Success\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: array\n" +
+				"                items:\n" +
+				"                  type: object\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "OpenAPI 3.0.3 spec should parse successfully");
+			assertEquals("3.0.3", openAPI.getOpenapi(), "Should detect OpenAPI version 3.0.3");
+
+			SoapUIProject project = new SoapUIProject("ProductsAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should generate valid XML");
+			assertTrue(xml.contains("getProducts"), "Generated XML should contain operation");
+		}
+	}
+
+	@Nested
+	@DisplayName("OpenAPI 3.1.x Support")
+	class OpenAPI31Support {
+
+		@Test
+		@DisplayName("Should parse OpenAPI 3.1.0 spec")
+		void testParseOpenAPI310() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Modern API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com/v1\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: listItems\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Success\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n" +
+				"                properties:\n" +
+				"                  id:\n" +
+				"                    type: integer\n" +
+				"                  name:\n" +
+				"                    type: string\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "OpenAPI 3.1.0 spec should parse successfully");
+			assertEquals("3.1.0", openAPI.getOpenapi(), "Should detect OpenAPI version 3.1.0");
+
+			SoapUIProject project = new SoapUIProject("ModernAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("listItems"), "Generated XML should contain operation");
+			assertTrue(xml.length() > 0, "Should generate valid XML");
+		}
+
+		@Test
+		@DisplayName("Should handle OpenAPI 3.1.0 with JSON Schema 2020-12")
+		void testOpenAPI310WithJsonSchema202012() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: JSON Schema API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    post:\n" +
+				"      operationId: postData\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"              properties:\n" +
+				"                value:\n" +
+				"                  type: [string, number]\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "OpenAPI 3.1.0 with JSON Schema should parse successfully");
+
+			SoapUIProject project = new SoapUIProject("JSONSchemaAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("postData"), "Generated XML should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should handle OpenAPI 3.1.0 with nullable types")
+		void testOpenAPI310WithNullableTypes() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Nullable API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /nullable:\n" +
+				"    get:\n" +
+				"      operationId: getNullable\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n" +
+				"                properties:\n" +
+				"                  optionalField:\n" +
+				"                    type: [string, null]\n" +
+				"                  requiredField:\n" +
+				"                    type: string\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "OpenAPI 3.1.0 with nullable types should parse");
+
+			SoapUIProject project = new SoapUIProject("NullableAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should generate valid XML with nullable types");
+		}
+
+		@Test
+		@DisplayName("Should handle OpenAPI 3.1.0 with examples at component level")
+		void testOpenAPI310WithExamples() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Examples API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    get:\n" +
+				"      operationId: getUsers\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Success\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                $ref: '#/components/schemas/User'\n" +
+				"components:\n" +
+				"  schemas:\n" +
+				"    User:\n" +
+				"      type: object\n" +
+				"      properties:\n" +
+				"        id:\n" +
+				"          type: integer\n" +
+				"          example: 123\n" +
+				"        name:\n" +
+				"          type: string\n" +
+				"          example: John Doe\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "OpenAPI 3.1.0 with examples should parse");
+
+			SoapUIProject project = new SoapUIProject("ExamplesAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getUsers"), "Should contain operation");
+		}
+
+		@Test
+		@DisplayName("Should parse OpenAPI 3.1.0 with multiple content types")
+		void testOpenAPI310WithMultipleContentTypes() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Multi Content API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    post:\n" +
+				"      operationId: postData\n" +
+				"      requestBody:\n" +
+				"        content:\n" +
+				"          application/json:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"          application/xml:\n" +
+				"            schema:\n" +
+				"              type: object\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "Should parse multiple content types");
+
+			SoapUIProject project = new SoapUIProject("MultiAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should generate valid XML");
+		}
+	}
+
+	@Nested
+	@DisplayName("Version-Agnostic Feature Support")
+	class VersionAgnosticFeatures {
+
+		@Test
+		@DisplayName("readOnly option should work with OpenAPI 3.0.0")
+		void testReadOnlyWith300() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.0.0\n" +
+				"info:\n" +
+				"  title: Test API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    get:\n" +
+				"      operationId: getData\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    post:\n" +
+				"      operationId: postData\n" +
+				"      responses:\n" +
+				"        '201':\n" +
+				"          description: Created\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+			options.setReadOnly(true);
+
+			SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getData"), "Should contain GET operation");
+			assertFalse(xml.contains("postData"), "Should exclude POST operation with readOnly");
+		}
+
+		@Test
+		@DisplayName("readOnly option should work with OpenAPI 3.1.0")
+		void testReadOnlyWith310() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Test API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /data:\n" +
+				"    get:\n" +
+				"      operationId: getData\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"    put:\n" +
+				"      operationId: updateData\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: Updated\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+			options.setReadOnly(true);
+
+			SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getData"), "Should contain GET operation");
+			assertFalse(xml.contains("updateData"), "Should exclude PUT operation with readOnly");
+		}
+
+		@Test
+		@DisplayName("serverPattern should work with OpenAPI 3.1.0")
+		void testServerPatternWith310() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Multi-Server API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://prod.example.com\n" +
+				"  - url: http://staging.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: getItems\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProjectOptions options = new SoapUIProjectOptions();
+			options.setServerPattern("staging");
+
+			SoapUIProject project = new SoapUIProject("API", openAPI, null, null, null, options);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("staging.example.com"), "Should use staging server");
+			assertFalse(xml.contains("prod.example.com"), "Should not use production server");
+		}
+	}
+
+	@Nested
+	@DisplayName("OpenAPI 3.2 Forward Compatibility")
+	class OpenAPI32Support {
+
+		@Test
+		@DisplayName("Note: OpenAPI 3.2 is not officially released yet")
+		void testOpenAPI32Status() {
+			String message = "OpenAPI 3.2 support: Not yet released as of 2026-04-27. " +
+				"When released, swagger-parser will need to be updated to support it. " +
+				"Current version (2.0.24) supports OpenAPI 3.0.x and 3.1.x.";
+			assertTrue(message.contains("3.2"), "Documentation note for 3.2 support");
+		}
+
+		@Test
+		@DisplayName("Should gracefully handle future OpenAPI versions")
+		void testFutureVersionHandling() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Test API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /test:\n" +
+				"    get:\n" +
+				"      operationId: test\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			assertNotNull(openAPI, "Parser should handle current versions");
+
+			SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should generate valid XML");
+		}
+	}
+
+	@Nested
+	@DisplayName("Complex Schema Support Across Versions")
+	class ComplexSchemaSupport {
+
+		@Test
+		@DisplayName("Should handle deeply nested objects in OpenAPI 3.1.0")
+		void testDeeplyNestedObjects() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Nested API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /nested:\n" +
+				"    get:\n" +
+				"      operationId: getNested\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n" +
+				"                properties:\n" +
+				"                  level1:\n" +
+				"                    type: object\n" +
+				"                    properties:\n" +
+				"                      level2:\n" +
+				"                        type: object\n" +
+				"                        properties:\n" +
+				"                          level3:\n" +
+				"                            type: string\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("NestedAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should handle deeply nested structures");
+		}
+
+		@Test
+		@DisplayName("Should handle arrays of objects in OpenAPI 3.1.0")
+		void testArrayOfObjects() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Array API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /items:\n" +
+				"    get:\n" +
+				"      operationId: getItems\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: array\n" +
+				"                items:\n" +
+				"                  type: object\n" +
+				"                  properties:\n" +
+				"                    id:\n" +
+				"                      type: integer\n" +
+				"                    name:\n" +
+				"                      type: string\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("ArrayAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should handle arrays of objects");
+		}
+
+		@Test
+		@DisplayName("Should handle allOf composition in OpenAPI 3.1.0")
+		void testAllOfComposition() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.1.0\n" +
+				"info:\n" +
+				"  title: Composition API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com\n" +
+				"paths:\n" +
+				"  /users:\n" +
+				"    get:\n" +
+				"      operationId: getUsers\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                allOf:\n" +
+				"                  - type: object\n" +
+				"                    properties:\n" +
+				"                      id:\n" +
+				"                        type: integer\n" +
+				"                  - type: object\n" +
+				"                    properties:\n" +
+				"                      name:\n" +
+				"                        type: string\n";
+
+			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
+			SoapUIProject project = new SoapUIProject("CompositionAPI", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.length() > 0, "Should handle allOf composition");
+		}
+	}
+}

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/model/OpenAPIVersionSupportTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/model/OpenAPIVersionSupportTest.java
@@ -412,23 +412,25 @@ class OpenAPIVersionSupportTest {
 		@Test
 		@DisplayName("Should parse OpenAPI 3.2.0 spec")
 		void testParseOpenAPI320() throws IOException, XmlException, SoapUIException {
-			String spec = "openapi: 3.2.0\n" +
-				"info:\n" +
-				"  title: OpenAPI 32 API\n" +
-				"  version: 1.0.0\n" +
-				"servers:\n" +
-				"  - url: http://api.example.com/v1\n" +
-				"paths:\n" +
-				"  /status:\n" +
-				"    get:\n" +
-				"      operationId: getStatus\n" +
-				"      responses:\n" +
-				"        '200':\n" +
-				"          description: OK\n" +
-				"          content:\n" +
-				"            application/json:\n" +
-				"              schema:\n" +
-				"                type: object\n";
+			String spec = """
+				openapi: 3.2.0
+				info:
+				  title: OpenAPI 32 API
+				  version: 1.0.0
+				servers:
+				  - url: http://api.example.com/v1
+				paths:
+				  /status:
+				    get:
+				      operationId: getStatus
+				      responses:
+				        '200':
+				          description: OK
+				          content:
+				            application/json:
+				              schema:
+				                type: object
+				""";
 
 			OpenAPI openAPI = SerializedDataUtils.parseOpenAPIContent(spec);
 			assertNotNull(openAPI, "OpenAPI 3.2.0 spec should parse successfully");
@@ -445,27 +447,29 @@ class OpenAPIVersionSupportTest {
 		@Test
 		@DisplayName("Should handle OpenAPI 3.2 querystring parameter")
 		void testOpenAPI32QuerystringParameterSupport() throws IOException, XmlException, SoapUIException {
-			String spec = "openapi: 3.2.0\n" +
-				"info:\n" +
-				"  title: Querystring API\n" +
-				"  version: 1.0.0\n" +
-				"servers:\n" +
-				"  - url: http://api.example.com\n" +
-				"paths:\n" +
-				"  /test:\n" +
-				"    get:\n" +
-				"      operationId: testQuerystring\n" +
-				"      parameters:\n" +
-				"        - name: rawQuery\n" +
-				"          in: querystring\n" +
-				"          required: false\n" +
-				"          content:\n" +
-				"            application/x-www-form-urlencoded:\n" +
-				"              schema:\n" +
-				"                type: string\n" +
-				"      responses:\n" +
-				"        '200':\n" +
-				"          description: OK\n";
+			String spec = """
+				openapi: 3.2.0
+				info:
+				  title: Querystring API
+				  version: 1.0.0
+				servers:
+				  - url: http://api.example.com
+				paths:
+				  /test:
+				    get:
+				      operationId: testQuerystring
+				      parameters:
+				        - name: rawQuery
+				          in: querystring
+				          required: false
+				          content:
+				            application/x-www-form-urlencoded:
+				              schema:
+				                type: string
+				      responses:
+				        '200':
+				          description: OK
+				""";
 
 			OpenAPI openAPI = SerializedDataUtils.parseOpenAPIContent(spec);
 			assertNotNull(openAPI, "OpenAPI 3.2 with querystring parameter should parse successfully");

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/model/OpenAPIVersionSupportTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/model/OpenAPIVersionSupportTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Nested;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
+import org.apiaddicts.apitools.openapi2soapui.util.SerializedDataUtils;
 import com.eviware.soapui.support.SoapUIException;
 
 import java.io.IOException;
@@ -405,43 +406,76 @@ class OpenAPIVersionSupportTest {
 	}
 
 	@Nested
-	@DisplayName("OpenAPI 3.2 Forward Compatibility")
+	@DisplayName("OpenAPI 3.2.x Support")
 	class OpenAPI32Support {
 
 		@Test
-		@DisplayName("Note: OpenAPI 3.2 is not officially released yet")
-		void testOpenAPI32Status() {
-			String message = "OpenAPI 3.2 support: Not yet released as of 2026-04-27. " +
-				"When released, swagger-parser will need to be updated to support it. " +
-				"Current version (2.0.24) supports OpenAPI 3.0.x and 3.1.x.";
-			assertTrue(message.contains("3.2"), "Documentation note for 3.2 support");
+		@DisplayName("Should parse OpenAPI 3.2.0 spec")
+		void testParseOpenAPI320() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.2.0\n" +
+				"info:\n" +
+				"  title: OpenAPI 32 API\n" +
+				"  version: 1.0.0\n" +
+				"servers:\n" +
+				"  - url: http://api.example.com/v1\n" +
+				"paths:\n" +
+				"  /status:\n" +
+				"    get:\n" +
+				"      operationId: getStatus\n" +
+				"      responses:\n" +
+				"        '200':\n" +
+				"          description: OK\n" +
+				"          content:\n" +
+				"            application/json:\n" +
+				"              schema:\n" +
+				"                type: object\n";
+
+			OpenAPI openAPI = SerializedDataUtils.parseOpenAPIContent(spec);
+			assertNotNull(openAPI, "OpenAPI 3.2.0 spec should parse successfully");
+			assertEquals("3.1.0", openAPI.getOpenapi(), "3.2 spec should be normalized to parser-compatible version");
+
+			SoapUIProject project = new SoapUIProject("OpenAPI32API", openAPI, null, null, null, null);
+			String xml = project.getFileContent();
+			project.deleteTemporaryFile();
+
+			assertTrue(xml.contains("getStatus"), "Generated XML should contain operation");
+			assertFalse(xml.isEmpty(), "Should generate valid XML");
 		}
 
 		@Test
-		@DisplayName("Should gracefully handle future OpenAPI versions")
-		void testFutureVersionHandling() throws IOException, XmlException, SoapUIException {
-			String spec = "openapi: 3.1.0\n" +
+		@DisplayName("Should handle OpenAPI 3.2 querystring parameter")
+		void testOpenAPI32QuerystringParameterSupport() throws IOException, XmlException, SoapUIException {
+			String spec = "openapi: 3.2.0\n" +
 				"info:\n" +
-				"  title: Test API\n" +
+				"  title: Querystring API\n" +
 				"  version: 1.0.0\n" +
 				"servers:\n" +
 				"  - url: http://api.example.com\n" +
 				"paths:\n" +
 				"  /test:\n" +
 				"    get:\n" +
-				"      operationId: test\n" +
+				"      operationId: testQuerystring\n" +
+				"      parameters:\n" +
+				"        - name: rawQuery\n" +
+				"          in: querystring\n" +
+				"          required: false\n" +
+				"          content:\n" +
+				"            application/x-www-form-urlencoded:\n" +
+				"              schema:\n" +
+				"                type: string\n" +
 				"      responses:\n" +
 				"        '200':\n" +
 				"          description: OK\n";
 
-			OpenAPI openAPI = parser.readContents(spec).getOpenAPI();
-			assertNotNull(openAPI, "Parser should handle current versions");
+			OpenAPI openAPI = SerializedDataUtils.parseOpenAPIContent(spec);
+			assertNotNull(openAPI, "OpenAPI 3.2 with querystring parameter should parse successfully");
 
-			SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, null);
+			SoapUIProject project = new SoapUIProject("QuerystringAPI", openAPI, null, null, null, null);
 			String xml = project.getFileContent();
 			project.deleteTemporaryFile();
 
-			assertTrue(xml.length() > 0, "Should generate valid XML");
+			assertTrue(xml.contains("testQuerystring"), "Generated XML should contain operation");
+			assertFalse(xml.isEmpty(), "Should generate valid XML");
 		}
 	}
 

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProjectFeatureTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/model/SoapUIProjectFeatureTest.java
@@ -1,0 +1,248 @@
+package org.apiaddicts.apitools.openapi2soapui.model;
+
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.apiaddicts.apitools.openapi2soapui.request.ExampleSet;
+import org.apiaddicts.apitools.openapi2soapui.request.ExampleValues;
+import org.apiaddicts.apitools.openapi2soapui.request.SoapUIProjectOptions;
+import com.eviware.soapui.support.SoapUIException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("SoapUIProject Feature Tests")
+class SoapUIProjectFeatureTest {
+
+	private OpenAPI openAPI;
+
+	@BeforeEach
+	void setUp() {
+		String spec = "openapi: 3.0.0\n" +
+			"info:\n" +
+			"  title: Test API\n" +
+			"  version: 1.0.0\n" +
+			"servers:\n" +
+			"  - url: http://api.example.com/v1\n" +
+			"  - url: http://staging.example.com/v1\n" +
+			"paths:\n" +
+			"  /users:\n" +
+			"    get:\n" +
+			"      operationId: listUsers\n" +
+			"      responses:\n" +
+			"        '200':\n" +
+			"          description: OK\n" +
+			"          content:\n" +
+			"            application/json:\n" +
+			"              schema:\n" +
+			"                type: object\n" +
+			"    post:\n" +
+			"      operationId: createUser\n" +
+			"      requestBody:\n" +
+			"        content:\n" +
+			"          application/json:\n" +
+			"            schema:\n" +
+			"              type: object\n" +
+			"      responses:\n" +
+			"        '201':\n" +
+			"          description: Created\n" +
+			"          content:\n" +
+			"            application/json:\n" +
+			"              schema:\n" +
+			"                type: object\n";
+		openAPI = new OpenAPIV3Parser().readContents(spec).getOpenAPI();
+	}
+
+	@Test
+	@DisplayName("Feature 1: readOnly - should exclude write operations")
+	void testReadOnlyFeature() throws IOException, XmlException, SoapUIException {
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setReadOnly(true);
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should contain GET (read operation)
+		assertTrue(xml.contains("listUsers") || xml.contains("GET"), "Read operations should be included");
+		// Should NOT contain POST (write operation)
+		assertFalse(xml.contains("createUser"), "Write operations should be excluded in readOnly mode");
+	}
+
+	@Test
+	@DisplayName("Feature 2: serverPattern - should select matching server")
+	void testServerPatternFeature() throws IOException, XmlException, SoapUIException {
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setServerPattern("staging");
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should contain staging server URL
+		assertTrue(xml.contains("staging.example.com"), "Staging server should be used when pattern matches");
+		// Should NOT contain production server
+		assertFalse(xml.contains("api.example.com") && xml.contains("staging.example.com") && xml.indexOf("api.example.com") < xml.indexOf("staging.example.com"),
+			"Should prefer staging server over production");
+	}
+
+	@Test
+	@DisplayName("Feature 3: minimalEndpoints - should only generate Success test case")
+	void testMinimalEndpointsFeature() throws IOException, XmlException, SoapUIException {
+		java.util.Set<String> testCases = new java.util.HashSet<>();
+		testCases.add("Success");
+		testCases.add("ErrorCase");
+
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setMinimalEndpoints(true);
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, testCases, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should have Success_TestCase
+		assertTrue(xml.contains("Success_TestCase"), "Success test case should always be present");
+		// Should NOT have ErrorCase_TestCase when minimalEndpoints is true
+		assertFalse(xml.contains("ErrorCase_TestCase"), "ErrorCase should be excluded in minimal mode");
+	}
+
+	@Test
+	@DisplayName("Feature 4: microcksHeaders - should add X-Microcks-Response-Name header")
+	void testMicrocksHeadersFeature() throws IOException, XmlException, SoapUIException {
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setMicrocksHeaders(true);
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should contain Microcks header
+		assertTrue(xml.contains("X-Microcks-Response-Name"), "Microcks header should be added");
+		// Should contain operationId as header value
+		assertTrue(xml.contains("listUsers") || xml.contains("createUser"), "OperationId should be used as header value");
+	}
+
+	@Test
+	@DisplayName("Feature 5: generateOneOfAnyOf - should not break with option enabled")
+	void testGenerateOneOfAnyOfFeature() throws IOException, XmlException, SoapUIException {
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setGenerateOneOfAnyOf(true);
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should successfully generate project with generateOneOfAnyOf enabled
+		assertTrue(xml.contains("TestAPI"), "Project should be created with generateOneOfAnyOf option enabled");
+		assertTrue(xml.length() > 100, "XML should contain valid project structure");
+	}
+
+	@Test
+	@DisplayName("Feature 6: examples - should use custom example values")
+	void testCustomExamplesFeature() throws IOException, XmlException, SoapUIException {
+		ExampleSet exampleSet = new ExampleSet();
+		exampleSet.setString("custom_string");
+		exampleSet.setNumber(999);
+		exampleSet.setBooleanValue(false);
+		exampleSet.setDate("2025-12-31");
+		exampleSet.setDateTime("2025-12-31T23:59:59.000+00:00");
+
+		ExampleValues exampleValues = new ExampleValues();
+		exampleValues.setSuccessful(exampleSet);
+
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setExamples(exampleValues);
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should have valid XML structure
+		assertTrue(xml.contains("TestAPI"), "Project should be created with custom examples");
+		assertTrue(xml.length() > 100, "XML should contain project structure");
+	}
+
+	@Test
+	@DisplayName("Feature 7: validateSchema - should add Groovy validation step")
+	void testValidateSchemaFeature() throws IOException, XmlException, SoapUIException {
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setValidateSchema(true);
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should contain Groovy validation step
+		assertTrue(xml.contains("Validation_TestStep"), "Validation step should be added");
+		assertTrue(xml.contains("groovy"), "Groovy script should be added");
+		assertTrue(xml.contains("2xx") || xml.contains("statusCode"), "Validation should check status code");
+	}
+
+	@Test
+	@DisplayName("All features combined - should work together")
+	void testAllFeaturesEnabled() throws IOException, XmlException, SoapUIException {
+		ExampleSet exampleSet = new ExampleSet();
+		exampleSet.setString("test");
+		exampleSet.setNumber(42);
+
+		ExampleValues exampleValues = new ExampleValues();
+		exampleValues.setSuccessful(exampleSet);
+
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setReadOnly(true);
+		options.setServerPattern("staging");
+		options.setMinimalEndpoints(true);
+		options.setMicrocksHeaders(true);
+		options.setGenerateOneOfAnyOf(true);
+		options.setExamples(exampleValues);
+		options.setValidateSchema(true);
+
+		java.util.Set<String> testCases = new java.util.HashSet<>();
+		testCases.add("Success");
+		testCases.add("Alternate");
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, testCases, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Verify all features are applied
+		assertTrue(xml.contains("staging.example.com"), "Server pattern applied");
+		assertTrue(xml.contains("X-Microcks-Response-Name"), "Microcks headers applied");
+		assertTrue(xml.contains("Validation_TestStep"), "Validation step applied");
+		assertTrue(xml.contains("Success_TestCase"), "Success test case present");
+		assertFalse(xml.contains("Alternate_TestCase"), "Alternate test case excluded");
+	}
+
+	@Test
+	@DisplayName("Null options should use defaults")
+	void testNullOptionsUsesDefaults() throws IOException, XmlException, SoapUIException {
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, null);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should include both read and write operations
+		assertTrue(xml.contains("listUsers") && (xml.contains("createUser") || xml.contains("POST")),
+			"Default behavior should include all operations");
+		// Should have default server
+		assertTrue(xml.contains("api.example.com"), "Should use first server by default");
+	}
+
+	@Test
+	@DisplayName("Empty options should use defaults")
+	void testEmptyOptionsUsesDefaults() throws IOException, XmlException, SoapUIException {
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+
+		SoapUIProject project = new SoapUIProject("TestAPI", openAPI, null, null, null, options);
+		String xml = project.getFileContent();
+		project.deleteTemporaryFile();
+
+		// Should include both operations
+		assertTrue(xml.contains("listUsers") && (xml.contains("createUser") || xml.contains("POST")),
+			"Default options should include all operations");
+	}
+}

--- a/src/test/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectOptionsTest.java
+++ b/src/test/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectOptionsTest.java
@@ -1,0 +1,60 @@
+package org.apiaddicts.apitools.openapi2soapui.request;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SoapUIProjectOptionsTest {
+
+	@Test
+	void testDefaultValues() {
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+
+		assertFalse(options.isReadOnly());
+		assertNull(options.getServerPattern());
+		assertFalse(options.isMinimalEndpoints());
+		assertFalse(options.isMicrocksHeaders());
+		assertFalse(options.isGenerateOneOfAnyOf());
+		assertNull(options.getExamples());
+		assertFalse(options.isValidateSchema());
+	}
+
+	@Test
+	void testSetAllOptions() {
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setReadOnly(true);
+		options.setServerPattern("staging");
+		options.setMinimalEndpoints(true);
+		options.setMicrocksHeaders(true);
+		options.setGenerateOneOfAnyOf(true);
+		options.setValidateSchema(true);
+
+		assertTrue(options.isReadOnly());
+		assertEquals("staging", options.getServerPattern());
+		assertTrue(options.isMinimalEndpoints());
+		assertTrue(options.isMicrocksHeaders());
+		assertTrue(options.isGenerateOneOfAnyOf());
+		assertTrue(options.isValidateSchema());
+	}
+
+	@Test
+	void testExamplesConfiguration() {
+		ExampleSet exampleSet = new ExampleSet();
+		exampleSet.setString("test");
+		exampleSet.setNumber(42);
+		exampleSet.setBooleanValue(false);
+		exampleSet.setDate("2026-01-01");
+		exampleSet.setDateTime("2026-01-01T00:00:00.000+00:00");
+
+		ExampleValues exampleValues = new ExampleValues();
+		exampleValues.setSuccessful(exampleSet);
+
+		SoapUIProjectOptions options = new SoapUIProjectOptions();
+		options.setExamples(exampleValues);
+
+		assertNotNull(options.getExamples());
+		assertEquals("test", options.getExamples().getSuccessful().getString());
+		assertEquals(42, options.getExamples().getSuccessful().getNumber());
+		assertFalse(options.getExamples().getSuccessful().getBooleanValue());
+	}
+}


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): **Runtime/toolchain upgrade — Java 17 & Spring Boot 3**

## What is the current behavior?

The project targets **Java 11 / Spring Boot 2.5.2** and uses an older `swagger-parser` (2.0.24) that only parses **OpenAPI 3.0.x** reliably. SoapUI project generation offers no configuration options — every request produces the same full project.

Issue Number: N/A

## What is the new behavior?

- **OpenAPI 3.1 & 3.2 support.** Upgraded `swagger-parser` to 2.1.42 for native 3.1 parsing (JSON Schema 2020-12, `type: [string, null]`, component-level examples), and added a project-level normalization layer (`SerializedDataUtils.normalizeOpenAPI32Content`) that maps 3.2-only constructs (`querystring` params, `query` operation, `$self`, `additionalOperations`, `components.mediaTypes`) onto a parseable 3.1 form. Version is auto-detected from the `openapi` field.
- **Java 17 / Spring Boot 3.3.0 upgrade.** Bumped the parent to Spring Boot 3.3.0, migrated `javax.*` → `jakarta.*`, switched springdoc to `springdoc-openapi-starter-webmvc-ui` 2.6.0, pinned the compiler plugin to Java 17, and updated the `Dockerfile` base image to `openjdk:17-jdk`.
- **7 optional generation options (openapi2postman feature parity).** New optional `options` object on the request: `readOnly`, `serverPattern`, `minimalEndpoints`, `microcksHeaders`, `generateOneOfAnyOf`, `examples`, and `validateSchema`. All options are backward-compatible — requests without an `options` field behave exactly as before.
- **Comprehensive test suite.** Added ~15 OpenAPI version-support tests plus integration tests covering end-to-end generation, HTTP method handling, parameter/schema handling, edge cases, and the new feature flags.
- **Documentation.** Added `OPENAPI_VERSIONS.md` and expanded the `README.md` (Java 17, 3.1/3.2 support, advanced-options reference) and `api.yaml`.
- **Version bump** to `2.0.0` (breaking toolchain change).

## Other information

- The `2.0.0` bump reflects the breaking runtime requirement: **Java 17 is now required to build and run** the service.
- OpenAPI 3.2.0 support is delivered through a compatibility normalization layer rather than native parser support, since `swagger-parser` does not yet fully support 3.2; this keeps generation working today and can be simplified once upstream parser support lands.