### PR TITLE
feat: migrate to Java 21 and Spring Boot 3.5.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Claude Code
+.claude/settings.local.json
+CLAUDE.local.md
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.0-beta-1] - 2026-07-20
+
+### Changed
+- **Upgraded to Java 21 and Spring Boot 3.5.16** (from Java 11 / Spring Boot 2.5.2). Migrates the Jakarta EE namespace (`javax.validation` → `jakarta.validation`) and replaces `springdoc-openapi-ui` 1.5.6 with `springdoc-openapi-starter-webmvc-ui` 2.8.17. The request/response contract and the generated SoapUI project output are unchanged.
+- **Dependency refresh:** SoapUI `5.6.0` → `5.9.1` (now on Log4j2 + Groovy 3), swagger-parser `2.1.39` → `2.1.45`, Lombok → `1.18.46`. SoapUI 5.9.1's `DefaultSoapUICore` requires the Log4j2 `log4j-core` backend, so `log4j-to-slf4j` is excluded from the Spring Boot starters (the app itself still logs via SLF4J → Logback); the `guava` and `wsdl4j` SoapUI exclusions were removed because 5.9.1 needs them at runtime.
+- **Slimmer artifact:** excluded SoapUI 5.9.1's bundled telemetry (SmartBear analytics → Mixpanel / Segment / OkHttp / Kotlin) and its GraphQL support, both unused by headless REST/OpenAPI generation (~7 MB, 23 jars). `org.json` is now a direct dependency (`20260522`); it was previously present only transitively via that telemetry. Other heavy SoapUI transitives (BouncyCastle, RSyntaxTextArea, Rhino, HtmlUnit, TestNG, Saxon/Xalan, Jersey) are loaded by SoapUI's eager core initialization and must remain.
+- **Deployment:** WAR deployment now requires a Jakarta / Servlet 6 container — **Tomcat 10.1+** (previously Tomcat 9). The Docker base image is now `eclipse-temurin:21-jdk`.
+- Trailing-slash URL matching is disabled by default in Spring 6, so `POST .../soap-ui-projects/` (with a trailing slash) no longer matches; use `.../soap-ui-projects`.
+
 ## [1.1.0-beta-1] - 2026-07-15
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk
+FROM eclipse-temurin:21-jdk
 
 ARG JAR_FILE
 COPY ${JAR_FILE} app.jar

--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ The variables are obtained from:
 
 |Technology              |Description                 |
 |------------------------|----------------------------|
-|Core Framework          |Spring Boot 2               |
+|Core Framework          |Spring Boot 3               |
 
 ### Server - Backend
 
 |Technology                                               |Description                                                                   |
 |---------------------------------------------------------|------------------------------------------------------------------------------|
-|[JDK 11](https://docs.oracle.com/en/java/javase/11/)                       |Java Development Kit                                                          |
-|[Spring Boot 2](https://spring.io/projects/spring-boot)  |Framework to ease the bootstrapping and development of new Spring Applications|
+|[JDK 21](https://docs.oracle.com/en/java/javase/21/)                       |Java Development Kit                                                          |
+|[Spring Boot 3](https://spring.io/projects/spring-boot)  |Framework to ease the bootstrapping and development of new Spring Applications|
 |[Maven 3](https://maven.apache.org)                      |Dependency Management                                                         |
-|[Tomcat 9](https://tomcat.apache.org)                    |Server deploy WAR                                                             |
+|[Tomcat 10.1+](https://tomcat.apache.org)                |Server deploy WAR (Jakarta EE / Servlet 6)                                    |
 
 ###  Libraries and Plugins
 |Technology              |Description                 |
@@ -98,7 +98,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 ### Prerequisites
 
-* [JDK Installation](https://docs.oracle.com/en/java/javase/11/install/overview-jdk-installation.html#GUID-8677A77F-231A-40F7-98B9-1FD0B48C346A)
+* [JDK Installation](https://docs.oracle.com/en/java/javase/21/install/overview-jdk-installation.html)
 * [Apache Maven Installation](https://maven.apache.org/install.html)
 * [Setting up Lombok](https://projectlombok.org/setup/overview)
   * [Eclipse and its offshoots](https://projectlombok.org/setup/eclipse)

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 		<springdoc.version>2.8.17</springdoc.version>
 		<soapui.version>5.9.1</soapui.version>
 		<swagger-parser.version>2.1.45</swagger-parser.version>
+		<json.version>20260522</json.version>
 		<lombok.version>1.18.46</lombok.version>
 	</properties>
 
@@ -431,7 +432,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20260522</version>
+			<version>${json.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.2</version>
+		<version>3.5.16</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>net.cloudappi</groupId>
 	<artifactId>openapi2soapui</artifactId>
-	<version>1.1.0-beta-1</version>
+	<version>2.0.0-beta-1</version>
 	<packaging>${packaging.type}</packaging>
 
 	<name>openapi2soapui</name>
@@ -48,19 +48,19 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
+		<java.version>21</java.version>
 
-		<springdoc.version>1.5.6</springdoc.version>
-		<soapui.version>5.6.0</soapui.version>
-		<swagger-parser.version>2.1.39</swagger-parser.version>
-		<lombok.version>1.18.30</lombok.version>
+		<springdoc.version>2.8.17</springdoc.version>
+		<soapui.version>5.9.1</soapui.version>
+		<swagger-parser.version>2.1.45</swagger-parser.version>
+		<lombok.version>1.18.46</lombok.version>
 	</properties>
 
 	<profiles>
 		<profile>
 			<id>jar</id>
 			<properties>
-				<packaging.type>jar</packaging.type>				
+				<packaging.type>jar</packaging.type>
 			</properties>
 		</profile>
 		<profile>
@@ -69,7 +69,7 @@
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
-				 <packaging.type>war</packaging.type>				 
+				 <packaging.type>war</packaging.type>
 			</properties>
 		</profile>
 		<profile>
@@ -89,16 +89,29 @@
 			<properties>
                 <packaging.type>war</packaging.type>
 			</properties>
-		</profile>		
-	 </profiles>	
+		</profile>
+	 </profiles>
 
-	<dependencies>	
+	<dependencies>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<!-- SoapUI 5.9.x uses Log4j2 and DefaultSoapUICore.initLog() casts the LoggerContext
+				     to log4j-core's implementation. Spring Boot's log4j-to-slf4j bridge makes that
+				     context an SLF4JLoggerContext, causing a ClassCastException on SoapUIProject
+				     construction. Removing the bridge lets log4j-core (pulled by SoapUI) be the active
+				     Log4j2 backend; the app itself logs via SLF4J -> Logback and is unaffected. The
+				     exclusion is repeated on every starter that transitively pulls spring-boot-starter-logging
+				     (Maven exclusions are per-path). -->
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-to-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
-			
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
@@ -114,6 +127,13 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
+			<exclusions>
+				<!-- See spring-boot-starter-web: keep log4j-to-slf4j off the classpath for SoapUI. -->
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-to-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -125,9 +145,14 @@
 					<groupId>com.vaadin.external.google</groupId>
 					<artifactId>android-json</artifactId>
 				</exclusion>
+				<!-- See spring-boot-starter-web: keep log4j-to-slf4j off the test classpath for SoapUI. -->
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-to-slf4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
- 
+
 		<dependency>
 		   <groupId>org.hibernate.validator</groupId>
 		   <artifactId>hibernate-validator</artifactId>
@@ -135,7 +160,7 @@
 
 		<dependency>
 			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-ui</artifactId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc.version}</version>
 		</dependency>
 
@@ -148,9 +173,23 @@
 					<groupId>javax.xml.bind</groupId>
 					<artifactId>jsr173_api</artifactId>
 				</exclusion>
+				<!-- Telemetry/analytics: SoapUI 5.9.x bundles SmartBear analytics (Mixpanel + Segment,
+				     transitively pulling okhttp/retrofit/kotlin). Not needed for headless project
+				     generation; excluding it removes the telemetry stack and trims the artifact. -->
 				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
+					<groupId>com.smartbear.utils.analytics</groupId>
+					<artifactId>analytics-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.smartbear.utils.analytics</groupId>
+					<artifactId>out-app-analytics-provider</artifactId>
+				</exclusion>
+				<!-- GraphQL support is not needed for REST/OpenAPI generation. NOTE: most other heavy
+				     SoapUI transitives (RSyntaxTextArea, BouncyCastle, Rhino, HtmlUnit, TestNG, Saxon/Xalan,
+				     Jersey…) ARE referenced by SoapUI's eager core init even headless and must NOT be excluded. -->
+				<exclusion>
+					<groupId>com.graphql-java</groupId>
+					<artifactId>graphql-java</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>commons-collections</groupId>
@@ -273,10 +312,6 @@
 					<artifactId>mail</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>wsdl4j</groupId>
-					<artifactId>wsdl4j</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>com.narupley</groupId>
 					<artifactId>not-going-to-be-commons-ssl</artifactId>
 				</exclusion>
@@ -387,15 +422,24 @@
 
 		<dependency>
 			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>      
+			<artifactId>snakeyaml</artifactId>
+		</dependency>
+
+		<!-- Used directly by SoapUIProject / SerializedDataUtils (org.json.JSONObject, JSONArray, JSONException).
+		     Declared explicitly instead of relying on it arriving transitively (it previously leaked in via
+		     SoapUI's bundled telemetry, which is now excluded). -->
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20260522</version>
 		</dependency>
 
 	</dependencies>
-	
+
 	<repositories>
 		<repository>
 			<id>SmartBearPluginRepository</id>
-			<url>https://rapi.tools.ops.smartbear.io/nexus/content/groups/public/</url>			
+			<url>https://rapi.tools.ops.smartbear.io/nexus/content/groups/public/</url>
 		</repository>
 	</repositories>
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/controller/SoapUIProjectController.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/controller/SoapUIProjectController.java
@@ -1,6 +1,6 @@
 package org.apiaddicts.apitools.openapi2soapui.controller;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import lombok.AllArgsConstructor;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/error/validators/AuthenticationConditional.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/error/validators/AuthenticationConditional.java
@@ -6,8 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 /**
  * Annotation for authentication property validations based on authentication type or grant type

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/error/validators/AuthenticationConditionalValidator.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/error/validators/AuthenticationConditionalValidator.java
@@ -4,8 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.BeanUtils;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/CustomAuthorizationRequest.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/CustomAuthorizationRequest.java
@@ -2,9 +2,9 @@ package org.apiaddicts.apitools.openapi2soapui.request;
 
 import java.util.List;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.Pattern;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/ExamplesConfig.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/ExamplesConfig.java
@@ -1,6 +1,6 @@
 package org.apiaddicts.apitools.openapi2soapui.request;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/Header.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/Header.java
@@ -1,6 +1,6 @@
 package org.apiaddicts.apitools.openapi2soapui.request;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/OAuth2Profile.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/OAuth2Profile.java
@@ -1,6 +1,6 @@
 package org.apiaddicts.apitools.openapi2soapui.request;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectRequest.java
+++ b/src/main/java/org/apiaddicts/apitools/openapi2soapui/request/SoapUIProjectRequest.java
@@ -3,8 +3,8 @@ package org.apiaddicts.apitools.openapi2soapui.request;
 import java.util.List;
 import java.util.Set;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,8 @@
 basepath=/api-openapi-to-soapui/v1
 springdoc.swagger-ui.url=/api.yaml
 springdoc.swagger-ui.path=${basepath}/swagger-ui.html
+
+# The service publishes its own curated OpenAPI contract as the static /api.yaml (see springdoc.swagger-ui.url).
+# Do NOT attach @ControllerAdvice-derived generic responses to operations: under springdoc 2.x that builds a
+# schema from Spring's ObjectError which serializes with a null map key, making /v3/api-docs fail with HTTP 500.
+springdoc.override-with-generic-response=false


### PR DESCRIPTION
Upgrade the runtime and framework baseline from **Java 11 / Spring Boot 2.5.2** to **Java 21 / Spring Boot 3.5.16** (Spring Framework 6.2, Jakarta EE 10). The request/response contract and the generated SoapUI project output are unchanged.

- Jakarta EE: migrate `javax.validation` -> `jakarta.validation` (8 files).
- springdoc: `openapi-ui` 1.5.6 -> `openapi-starter-webmvc-ui` 2.8.17. Set `springdoc.override-with-generic-response=false`; the auto `/v3/api-docs` otherwise 500s serializing the `@ControllerAdvice` `ObjectError` schema (the service publishes its own static `/api.yaml`).
- SoapUI 5.6.0 -> 5.9.1 (Log4j2 + Groovy 3): exclude `log4j-to-slf4j` so SoapUI's `log4j-core` backend initializes (the app still logs via SLF4J -> Logback); drop the `guava`/`wsdl4j` exclusions, which 5.9.1 needs at runtime.
- swagger-parser 2.1.39 -> 2.1.45, Lombok -> 1.18.46.
- Declare `org.json` explicitly (previously present only transitively via SoapUI's bundled telemetry).
- Slim the artifact (~7 MB): exclude SoapUI's telemetry (Mixpanel/Segment/OkHttp/Kotlin) and GraphQL support, unused by headless generation.
- Dockerfile base image `openjdk:11-jdk` -> `eclipse-temurin:21-jdk`.
- Docs: README stack/prerequisites (JDK 21, Tomcat 10.1+) and CHANGELOG.

Deployment note: WAR deployment now requires a Jakarta / Servlet 6 container (Tomcat 10.1+). All 194 tests pass on JDK 21; verified end-to-end with a live smoke test.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

The service runs on **Java 11 / Spring Boot 2.5.2** (both end-of-life; Boot 2.5.2 has no official Java 21 support). It uses the `javax.*` namespace for Bean Validation, `springdoc-openapi-ui` 1.5.6 and SoapUI 5.6.0. The WAR targets a Servlet 4 / Tomcat 9 container and the Docker image is based on `openjdk:11-jdk`. `org.json` is only present transitively, and the built artifact bundles SoapUI's telemetry and GraphQL transitive dependencies.

## What is the new behavior?

- Runs on **Java 21 / Spring Boot 3.5.16** (Spring Framework 6.2, Jakarta EE 10); Bean Validation migrated to `jakarta.validation` and springdoc to `springdoc-openapi-starter-webmvc-ui` 2.8.17. No other source changes were required — all `org.springframework.*` imports are stable in Boot 3.5.
- **SoapUI 5.6.0 -> 5.9.1** (Log4j2 + Groovy 3) with the logging/dependency adjustments needed to initialize cleanly under Spring Boot 3.5; swagger-parser 2.1.45, Lombok 1.18.46, and `org.json` now declared as a direct dependency.
- **Smaller artifact (~7 MB)** with SoapUI's telemetry and GraphQL support excluded. Behavior and output are unchanged — all 194 tests pass on JDK 21.

## Other information

**Deployment**
- WAR deployment now requires a **Jakarta / Servlet 6 container — Tomcat 10.1+** (previously Tomcat 9). The Docker image is now `eclipse-temurin:21-jdk`.
- Spring 6 disables trailing-slash matching by default: use `POST …/soap-ui-projects` (no trailing slash).

**Verification**
- `mvn clean test` → **194 tests, 0 failures, 0 errors** on JDK 21.
- WAR (default) and JAR (`-Pjar`) both package successfully.
- Live smoke test on the packaged JAR (embedded Tomcat 10.1.55): `POST /soap-ui-projects` returns a valid SoapUI project; `/api.yaml` (200), Swagger UI (302) and `/v3/api-docs` (200) all serve correctly; no runtime errors.

**Out of scope**
- OpenAPI 3.1/3.2 support is unchanged (3.0/3.1 work; 3.2 is not natively supported by swagger-parser). A dedicated 3.1/3.2 compatibility layer lives on `feature/openapi3132`.

**Base branch:** target `develop` (this branch was cut from `develop`; `main` is several releases behind).